### PR TITLE
Set Node.js v16 as minimum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Breaking change: Removed support for end-of-life versions of Node.js. A minimum of Node.js 16 is now required.
+
 ## [2.1.1] - 2022-12-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "require": "./lib/cjs/index.js"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "docs": "typedoc src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudamqp/amqp-client",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "description": "AMQP 0-9-1 client, both for browsers (WebSocket) and node (TCP Socket)",
   "type": "module",
   "main": "lib/cjs/index.js",

--- a/src/amqp-base-client.ts
+++ b/src/amqp-base-client.ts
@@ -3,7 +3,7 @@ import { AMQPError } from './amqp-error.js'
 import { AMQPMessage } from './amqp-message.js'
 import { AMQPView } from './amqp-view.js'
 
-const VERSION = '2.1.1'
+const VERSION = '3.0.0'
 
 /**
  * Base class for AMQPClients.


### PR DESCRIPTION
Blocks #68 and #71

This bumps the minimum version of Node.js to v16. This is a breaking change and requires a major version increment.

- See supported Node.js release schedule at https://nodejs.org/en/about/releases/
- Node.js 12 reached end-of-life 2022-04-30
- Node.js 14 reached end-of-life 2023-04-30

Node.js v20 was included in the test matrix