### PR TITLE
Fix intermitent condition where onerror is called when conn is closed by client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+#### Fixed
+
+- Call socket.destroy() when closing socket to fix intermitent condition where onerror is called when conn is closed by client.
+
 ## [2.1.1] - 2022-12-13
 
 ### Added

--- a/src/amqp-socket-client.ts
+++ b/src/amqp-socket-client.ts
@@ -150,7 +150,10 @@ export class AMQPClient extends AMQPBaseClient {
 
   protected override closeSocket(): void {
     this.closed = true
-    if (this.socket) this.socket.end()
+    if (this.socket) {
+      this.socket.end()
+      this.socket.destroy()
+    }
     this.socket = undefined
   }
 }


### PR DESCRIPTION
The test "onerror is not called when conn is closed by client" intermittently fails.

According to some resources, such as [RFC-1122](https://datatracker.ietf.org/doc/html/rfc1122#page-87) (4.2.2.12 Closing a Connection): if the host actively closes a connection, while still having unread incoming data available, the host should send the signal `RST` (losing any received data) instead of `FIN`. This may or may not be what is happening, but there's there's something causing a `RST` to be received by the client at least some of the time.

This pull request proposes the solution of calling `socket.destroy()` in `closeSocket()` to ignore the possibility of a `RST` response. This was also the solution in https://github.com/postwait/node-amqp/pull/444.

See recent past failures:

- https://github.com/cloudamqp/amqp-client.js/actions/runs/5131090828/job/13886861954#step:14:98
- https://github.com/ngbrown-forks/amqp-client.js/actions/runs/5613121714/job/15208428472#step:14:99
- https://github.com/ngbrown-forks/amqp-client.js/actions/runs/5601476456/job/15174015021#step:14:70