### PR TITLE
Package improvements for bundling and tree-shaking

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "ignorePatterns": ["types/", "dist/", "lib/"],
   "env": {
     "es2020": true,
     "browser": true
@@ -12,6 +13,7 @@
   },
   "plugins": ["@typescript-eslint"],
   "rules": {
-    "no-console": "off"
+    "no-console": "off",
+    "@typescript-eslint/consistent-type-imports": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,18 @@
     "tls": false
   },
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./lib/mjs/index.js",
-    "require": "./lib/cjs/index.js"
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./lib/mjs/index.js",
+      "require": "./lib/cjs/index.js"
+    },
+    "./*": {
+      "types": "./types/*.d.ts",
+      "import": "./lib/mjs/*.js",
+      "require": "./lib/cjs/*.js"
+    }
   },
+  "sideEffects": false,
   "engines": {
     "node": ">=16.0.0"
   },
@@ -63,16 +71,5 @@
     "typedoc": "^0.22.10",
     "typescript": "^4.6.4",
     "vitest": "^0.33.0"
-  },
-  "ava": {
-    "extensions": {
-      "ts": "module"
-    },
-    "nonSemVerExperiments": {
-      "configurableModuleFormat": true
-    },
-    "nodeArguments": [
-      "--loader=ts-node/esm"
-    ]
   }
 }

--- a/src/amqp-channel.ts
+++ b/src/amqp-channel.ts
@@ -2,9 +2,9 @@ import { AMQPError } from './amqp-error.js'
 import { AMQPView } from './amqp-view.js'
 import { AMQPQueue } from './amqp-queue.js'
 import { AMQPConsumer } from './amqp-consumer.js'
-import { AMQPMessage } from './amqp-message.js'
-import { AMQPBaseClient } from './amqp-base-client.js'
-import { AMQPProperties } from './amqp-properties.js'
+import type { AMQPMessage } from './amqp-message.js'
+import type { AMQPBaseClient } from './amqp-base-client.js'
+import type { AMQPProperties } from './amqp-properties.js'
 
 /**
  * Represents an AMQP Channel. Almost all actions in AMQP are performed on a Channel.

--- a/src/amqp-consumer.ts
+++ b/src/amqp-consumer.ts
@@ -1,6 +1,6 @@
 import { AMQPError } from './amqp-error.js'
-import { AMQPChannel } from './amqp-channel.js'
-import { AMQPMessage } from './amqp-message.js'
+import type { AMQPChannel } from './amqp-channel.js'
+import type { AMQPMessage } from './amqp-message.js'
 
 /**
  * A consumer, subscribed to a queue

--- a/src/amqp-error.ts
+++ b/src/amqp-error.ts
@@ -1,4 +1,4 @@
-import { AMQPBaseClient } from './amqp-base-client.js'
+import type { AMQPBaseClient } from './amqp-base-client.js'
 
 /**
  * An error, can be both AMQP level errors or socket errors

--- a/src/amqp-message.ts
+++ b/src/amqp-message.ts
@@ -1,5 +1,5 @@
-import { AMQPChannel } from './amqp-channel.js'
-import { AMQPProperties } from './amqp-properties.js'
+import type { AMQPChannel } from './amqp-channel.js'
+import type { AMQPProperties } from './amqp-properties.js'
 
 /**
  * AMQP message

--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -1,7 +1,7 @@
-import { AMQPMessage } from './amqp-message.js'
-import { AMQPChannel, ConsumeParams } from './amqp-channel.js'
-import { AMQPProperties } from './amqp-properties.js'
-import { AMQPConsumer } from './amqp-consumer.js'
+import type { AMQPMessage } from './amqp-message.js'
+import type { AMQPChannel, ConsumeParams } from './amqp-channel.js'
+import type { AMQPProperties } from './amqp-properties.js'
+import type { AMQPConsumer } from './amqp-consumer.js'
 
 /**
  * Convience class for queues

--- a/src/amqp-socket-client.ts
+++ b/src/amqp-socket-client.ts
@@ -1,6 +1,6 @@
 import { AMQPBaseClient } from './amqp-base-client.js'
 import { AMQPError } from './amqp-error.js'
-import { AMQPTlsOptions } from './amqp-tls-options'
+import { AMQPTlsOptions } from './amqp-tls-options.js'
 import { AMQPView } from './amqp-view.js'
 import { Buffer } from 'buffer'
 import * as net from 'net'

--- a/src/amqp-socket-client.ts
+++ b/src/amqp-socket-client.ts
@@ -1,6 +1,6 @@
 import { AMQPBaseClient } from './amqp-base-client.js'
 import { AMQPError } from './amqp-error.js'
-import { AMQPTlsOptions } from './amqp-tls-options.js'
+import type { AMQPTlsOptions } from './amqp-tls-options.js'
 import { AMQPView } from './amqp-view.js'
 import { Buffer } from 'buffer'
 import * as net from 'net'

--- a/src/amqp-tls-options.ts
+++ b/src/amqp-tls-options.ts
@@ -1,4 +1,4 @@
-import { TlsOptions } from 'tls'
+import type { TlsOptions } from 'tls'
 
 /** Additional TLS options, for more info check https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions 
  *  @cert Cert chains in PEM format. One cert chain should be provided per private key.

--- a/src/amqp-view.ts
+++ b/src/amqp-view.ts
@@ -1,4 +1,4 @@
-import { AMQPProperties, Field } from './amqp-properties.js'
+import type { AMQPProperties, Field } from './amqp-properties.js'
 
 /**
  * An extended DataView, with AMQP protocol specific methods.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "es2020",                               /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     "module": "es2020",                               /* Specify what module code is generated. */
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */


### PR DESCRIPTION
My application bundler (esbuild) wasn't able to completely tree-shake the `AMQPWebSocketClient` import and was adding a `node-modules-polyfills:buffer` to the output bundle.

This pull request resolves that through these changes:

- `"sideEffects": false,` in `package.json` [tells bundlers](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free) to not include an import if nothing is used from that import.
- Setting the subpath conditional exports lets individual library files be imported instead of just through `index.ts`. Eliminates any question if something is going to be removed or not by tree-shaking, since it isn't imported in the first place. End applications will need to use a TypeScript `moduleResolution` setting of `node16`, `nodenext`, or `bundler` to use the additional subpath exports.
- Removed the now obsolete `ava` config.
- Enabled `"moduleResolution": "node16"` to enforce all imports correctly. `"node"` is for node v11 and earlier behavior ([more info](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#moduleresolution-bundler)).
- Enable eslint rule `@typescript-eslint/consistent-type-imports` and fix errors. May also help bundlers if an import is only being included for its types.

This also closes #63 because the `AMQPBaseClient` will be importable directly from the `amqp-base-client.js` file:

```ts
import { AMQPBaseClient } from "@cloudamqp/amqp-client/amqp-base-client";
```

I've tested the changes on my local application.