### PR TITLE
Make time duration since last server data available

### DIFF
--- a/src/amqp-socket-client.ts
+++ b/src/amqp-socket-client.ts
@@ -58,6 +58,7 @@ export class AMQPClient extends AMQPBaseClient {
     socket.setTimeout((this.heartbeat || 60) * 1000)
     // enable TCP keepalive if AMQP heartbeats are disabled
     if (this.heartbeat === 0) socket.setKeepAlive(true, 60)
+    this.lastDataReceived = performance.now()
     return new Promise((resolve, reject) => {
       socket.on('timeout', () => reject(new AMQPError("timeout", this)))
       socket.on('error', (err) => reject(new AMQPError(err.message, this)))

--- a/src/amqp-websocket-client.ts
+++ b/src/amqp-websocket-client.ts
@@ -50,6 +50,7 @@ export class AMQPWebSocketClient extends AMQPBaseClient {
     this.socket = socket
     socket.binaryType = "arraybuffer"
     socket.onmessage = this.handleMessage.bind(this)
+    this.lastDataReceived = performance.now()
     return new Promise((resolve, reject) => {
       this.connectPromise = [resolve, reject]
       socket.addEventListener('close', reject)


### PR DESCRIPTION
With my WebSocket connection, I needed the client to re-connect when the connection wasn't active anymore. Setting the `heartbeat` would ensure the server sent something at a regular interval, but the application had no way to know when the heartbeats were.

This was the solution I came up with, on every received message, store the current `performance.now()` value, a monotonic millisecond timer. It had to be within this library, because the only message during the time period might be the heartbeat message. Then the application can check if it has been significantly greater than the heartbeat time since the last received message, and attempt to re-connect.