### PR TITLE
Raise an error when WebSocket is not cleanly closed

### DIFF
--- a/src/amqp-socket-client.ts
+++ b/src/amqp-socket-client.ts
@@ -82,7 +82,9 @@ export class AMQPClient extends AMQPBaseClient {
     conn.on('connect', () => {
       conn.on('error', (err) => this.onerror(new AMQPError(err.message, this)))
       conn.on('close', (hadError: boolean) => {
-        if (!hadError && !this.closed) this.onerror(new AMQPError("Socket closed", this))
+        const clientClosed = this.closed
+        this.closed = true
+        if (!hadError && !clientClosed) this.onerror(new AMQPError("Socket closed", this))
       })
     })
     return conn

--- a/src/amqp-websocket-client.ts
+++ b/src/amqp-websocket-client.ts
@@ -57,7 +57,9 @@ export class AMQPWebSocketClient extends AMQPBaseClient {
       socket.addEventListener('open', () => {
         socket.addEventListener('error', (ev: Event) => this.onerror(new AMQPError(ev.toString(), this)))
         socket.addEventListener('close', (ev: CloseEvent) => {
-          if (!ev.wasClean && !this.closed) this.onerror(new AMQPError(`connection not cleanly closed (${ev.code})`, this))
+          const clientClosed = this.closed
+          this.closed = true
+          if (!ev.wasClean && !clientClosed) this.onerror(new AMQPError(`connection not cleanly closed (${ev.code})`, this))
         })
         socket.send(new Uint8Array([65, 77, 81, 80, 0, 0, 9, 1]))
       })

--- a/test-browser/websocket.ts
+++ b/test-browser/websocket.ts
@@ -213,6 +213,17 @@ test('connection error raises on publish', async () => {
   await expect(q.publish("foobar")).rejects.toThrow()
 })
 
+test('closed socket closes client', async () => {
+  const amqp = getNewClient()
+  await amqp.connect()
+  const socket = amqp["socket"]
+  assert(socket, "Socket must be created")
+  const closed = new Promise((resolve) => socket.addEventListener('close', resolve))
+  socket.close()
+  await closed
+  expect(amqp.closed).toBe(true)
+})
+
 test('wait for publish confirms', async () => {
   const amqp = getNewClient()
   const conn = await amqp.connect()

--- a/test/test.ts
+++ b/test/test.ts
@@ -217,6 +217,17 @@ test('connection error raises on publish', async () => {
   await expect(q.publish("foobar")).rejects.toThrow()
 })
 
+test('closed socket closes client', async () => {
+  const amqp = getNewClient()
+  await amqp.connect()
+  const socket = amqp["socket"]
+  assert(socket, "Socket must be created")
+  const closed = new Promise((resolve) => socket.on('close', resolve))
+  socket.destroy()
+  await closed
+  expect(amqp.closed).toBe(true)
+})
+
 test('wait for publish confirms', async () => {
   const amqp = getNewClient()
   const conn = await amqp.connect()


### PR DESCRIPTION
When a WebSocket connection is closed at the network level, there's no error raised by the `AMQPWebSocketClient`.

This change calls the `onerror` method when the connection is not cleanly closed. I switched to using `addEventListener` so the `reject` handler wouldn't be replaced by the new `close` handler before the `openok` message is received.

I can test this by restarting a `websocket-relay` container in the middle of a session.

I don't know how to automatically test this, as the WebSocket needs to be killed. Merely calling `close` on the socket would be considered a clean close.

Update: I updated both the WebSocket and Node.js socket clients to set `closed` to `true` when the underlying socket is closed.