### PR TITLE
Throw and reject Promise with an Error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,8 @@
   },
   "plugins": ["@typescript-eslint"],
   "rules": {
-    "@typescript-eslint/consistent-type-imports": "error"
+    "@typescript-eslint/consistent-type-imports": "error",
+    "prefer-promise-reject-errors": "error",
+    "no-throw-literal": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "docs": "typedoc src/index.ts",
-    "lint": "eslint src",
+    "lint": "eslint .",
     "test": "vitest run --coverage",
     "test-browser": "vitest --config ./vitest.config.browser.ts",
     "prebuild": "rm -rf dist lib types",

--- a/src/amqp-socket-client.ts
+++ b/src/amqp-socket-client.ts
@@ -98,7 +98,7 @@ export class AMQPClient extends AMQPBaseClient {
         // first 7 bytes of a frame was split over two reads, this reads the second part
         if (this.framePos !== 0) {
           const copied = buf.copy(this.frameBuffer, this.framePos, bufPos, bufPos + 7 - this.framePos)
-          if (copied === 0) throw `Copied 0 bytes framePos=${this.framePos} bufPos=${bufPos} bytesWritten=${bufLen}`
+          if (copied === 0) throw new AMQPError(`Copied 0 bytes framePos=${this.framePos} bufPos=${bufPos} bytesWritten=${bufLen}`, this)
           this.frameSize = this.frameBuffer.readInt32BE(bufPos + 3) + 8
           this.framePos += copied
           bufPos += copied
@@ -107,7 +107,7 @@ export class AMQPClient extends AMQPBaseClient {
         // frame header is split over reads, copy to frameBuffer
         if (bufPos + 3 + 4 > bufLen) {
           const copied = buf.copy(this.frameBuffer, this.framePos, bufPos, bufLen)
-          if (copied === 0) throw `Copied 0 bytes framePos=${this.framePos} bufPos=${bufPos} bytesWritten=${bufLen}`
+          if (copied === 0) throw new AMQPError(`Copied 0 bytes framePos=${this.framePos} bufPos=${bufPos} bytesWritten=${bufLen}`, this)
           this.framePos += copied
           break
         }
@@ -127,7 +127,7 @@ export class AMQPClient extends AMQPBaseClient {
       const leftOfFrame = this.frameSize - this.framePos
       const copyBytes = Math.min(leftOfFrame, bufLen - bufPos)
       const copied = buf.copy(this.frameBuffer, this.framePos, bufPos, bufPos + copyBytes)
-      if (copied === 0) throw `Copied 0 bytes, please report this bug, frameSize=${this.frameSize} framePos=${this.framePos} bufPos=${bufPos} copyBytes=${copyBytes} bytesWritten=${bufLen}`
+      if (copied === 0) throw new AMQPError(`Copied 0 bytes, please report this bug, frameSize=${this.frameSize} framePos=${this.framePos} bufPos=${bufPos} copyBytes=${copyBytes} bytesWritten=${bufLen}`, this)
       this.framePos += copied
       bufPos += copied
       if (this.framePos === this.frameSize) {

--- a/src/amqp-view.ts
+++ b/src/amqp-view.ts
@@ -272,7 +272,7 @@ export class AMQPView extends DataView {
         break
       }
       default:
-        throw `Field type '${k}' not supported`
+        throw new Error(`Field type '${k}' not supported`)
     }
     return [v, i - byteOffset]
   }
@@ -333,7 +333,7 @@ export class AMQPView extends DataView {
         }
         break
       default:
-        throw `Unsupported field type '${field}'`
+        throw new Error(`Unsupported field type '${field}'`)
     }
     return i - byteOffset
   }

--- a/src/amqp-websocket-client.ts
+++ b/src/amqp-websocket-client.ts
@@ -76,7 +76,7 @@ export class AMQPWebSocketClient extends AMQPBaseClient {
           reject(err)
         }
       } else {
-        reject("Socket not connected")
+        reject(new AMQPError("Socket not connected", this))
       }
     })
   }

--- a/test-browser/websocket.ts
+++ b/test-browser/websocket.ts
@@ -593,7 +593,7 @@ test("onerror is not called when conn is closed by client", async () => {
   const conn = await amqp.connect()
   const callbackPromise = new Promise((done, reject) => {
   conn.onerror = vi.fn(
-      (err: AMQPError) => reject(`onerror should not be called when gracefully closed. Error was: ${err.message}`)
+      (err: AMQPError) => reject(new Error(`onerror should not be called when gracefully closed. Error was: ${err.message}`))
   )
     setTimeout(done, 10)
   })

--- a/test/test.ts
+++ b/test/test.ts
@@ -597,7 +597,7 @@ test("onerror is not called when conn is closed by client", async () => {
   const conn = await amqp.connect()
   const callbackPromise = new Promise((done, reject) => {
     conn.onerror = vi.fn(
-      (err: AMQPError) => reject(`onerror should not be called when gracefully closed. Error was: ${err.message}`)
+      (err: AMQPError) => reject(new Error(`onerror should not be called when gracefully closed. Error was: ${err.message}`))
     )
     setTimeout(done, 10)
   })


### PR DESCRIPTION
It is considered good practice to only throw the Error object itself or an object using the Error object as base objects for user-defined exceptions and to pass instances of the built-in Error object to the reject() function for user-defined errors in Promises. The fundamental benefit of Error objects is that they automatically keep track of where they were built and originated.

This pull request enables the [no-throw-literal](https://eslint.org/docs/latest/rules/no-throw-literal) and [prefer-promise-reject-errors](https://eslint.org/docs/latest/rules/prefer-promise-reject-errors) eslint rules and fixes the related issues.