### PR TITLE
Bump version while reading it from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,10 @@
     "lint": "eslint .",
     "test": "vitest run --coverage",
     "test-browser": "vitest --config ./vitest.config.browser.ts",
-    "prebuild": "rm -rf dist lib types && node -p '`export const VERSION = ${JSON.stringify(require(\"./package.json\").version)} // Generated at prebuild`' > src/version.ts",
+    "prebuild": "rm -rf dist lib types && npm run version",
     "build": "tsc && tsc --module commonjs --outDir lib/cjs && tsc --emitDeclarationOnly --removeComments false && rollup -c",
     "postbuild": "echo '{\"type\": \"commonjs\"}' > lib/cjs/package.json",
     "prepare": "npm run build",
-    "preversion": "npm test",
     "version": "sed -i'' \"s/VERSION = .*/VERSION = '$npm_package_version'/\" src/amqp-base-client.ts && git add src/amqp-base-client.ts"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudamqp/amqp-client",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "AMQP 0-9-1 client, both for browsers (WebSocket) and node (TCP Socket)",
   "type": "module",
   "main": "lib/cjs/index.js",
@@ -32,7 +32,7 @@
     "lint": "eslint .",
     "test": "vitest run --coverage",
     "test-browser": "vitest --config ./vitest.config.browser.ts",
-    "prebuild": "rm -rf dist lib types",
+    "prebuild": "rm -rf dist lib types && node -p '`export const VERSION = ${JSON.stringify(require(\"./package.json\").version)} // Generated at prebuild`' > src/version.ts",
     "build": "tsc && tsc --module commonjs --outDir lib/cjs && tsc --emitDeclarationOnly --removeComments false && rollup -c",
     "postbuild": "echo '{\"type\": \"commonjs\"}' > lib/cjs/package.json",
     "prepare": "npm run build",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "tsc && tsc --module commonjs --outDir lib/cjs && tsc --emitDeclarationOnly --removeComments false && rollup -c",
     "postbuild": "echo '{\"type\": \"commonjs\"}' > lib/cjs/package.json",
     "prepare": "npm run build",
-    "version": "sed -i'' \"s/VERSION = .*/VERSION = '$npm_package_version'/\" src/amqp-base-client.ts && git add src/amqp-base-client.ts"
+    "version": "sed -i'' \"s/VERSION = .*/VERSION = '$npm_package_version'/\" src/amqp-base-client.ts"
   },
   "files": [
     "src/",

--- a/src/amqp-base-client.ts
+++ b/src/amqp-base-client.ts
@@ -3,7 +3,8 @@ import { AMQPError } from './amqp-error.js'
 import { AMQPMessage } from './amqp-message.js'
 import { AMQPView } from './amqp-view.js'
 import type { Logger } from './types.js'
-import { VERSION } from './version.js'
+
+const VERSION = '3.1.1'
 
 /**
  * Base class for AMQPClients.

--- a/src/amqp-base-client.ts
+++ b/src/amqp-base-client.ts
@@ -3,8 +3,7 @@ import { AMQPError } from './amqp-error.js'
 import { AMQPMessage } from './amqp-message.js'
 import { AMQPView } from './amqp-view.js'
 import type { Logger } from './types.js'
-
-const VERSION = '3.0.0'
+import { VERSION } from './version.js'
 
 /**
  * Base class for AMQPClients.

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = "3.1.0" // Generated at prebuild

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,0 @@
-export const VERSION = "3.1.0" // Generated at prebuild


### PR DESCRIPTION
I forgot to bump `VERSION` constant when releasing `3.1.0`. This fixes that and prevents it from happening again.