### PR TITLE
chore: Publish to NPM with provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -19,7 +22,7 @@ jobs:
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - run: npm run build
-      - run: npm publish --access public
+      - run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
The release process in this repository is already automated via GitHub Actions, which is a great first step toward creating trust in the supply chain. Recently, NPM has started to support publishing with the `--provenance` flag. This flag creates a link between the GitHub Actions run that created the release and the final artifact on NPM. This linkage further ensures that package installs can be traced back to a specific code revision.

For more information on publishing with provenance, please refer to: https://github.blog/2023-04-19-introducing-npm-package-provenance/