### PR TITLE
Web Worker compability

### DIFF
--- a/src/amqp-websocket-client.ts
+++ b/src/amqp-websocket-client.ts
@@ -144,8 +144,8 @@ export class AMQPWebSocketClient extends AMQPBaseClient {
   }
 
   static platform(): string {
-    if (typeof(window) !== 'undefined')
-      return window.navigator.userAgent
+    if (typeof(navigator) !== 'undefined')
+      return navigator.userAgent
     else
       return `${process.release.name} ${process.version} ${process.platform} ${process.arch}`
   }


### PR DESCRIPTION
`window` is not available in Web Worker, but `navigator` should be. `navigator` should also be a top-level object in window context.

Fixes #117 