### PR TITLE
Always buffer all publish framed together

### DIFF
--- a/src/amqp-channel.ts
+++ b/src/amqp-channel.ts
@@ -288,7 +288,7 @@ export class AMQPChannel {
    * @param [immediate] - if the message should be returned if it can't be delivered to a consumer immediately (not supported in RabbitMQ)
    * @return - fulfilled when the message is enqueue on the socket, or if publish confirm is enabled when the message is confirmed by the server
    */
-  basicPublish(exchange: string, routingKey: string, data: string|Uint8Array|ArrayBuffer|Buffer|null, properties: AMQPProperties = {}, mandatory = false, immediate = false): Promise<number> {
+  async basicPublish(exchange: string, routingKey: string, data: string|Uint8Array|ArrayBuffer|Buffer|null, properties: AMQPProperties = {}, mandatory = false, immediate = false): Promise<number> {
     if (this.closed) return this.rejectClosed()
     if (this.connection.blocked)
       return Promise.reject(new AMQPError(`Connection blocked by server: ${this.connection.blocked}`, this.connection))


### PR DESCRIPTION
Even if the user doesn't await basicPublish all framed beloging to one publish should be published together. So intead of waiting for a potentially blocked socket to be drain enqueue all data and only await for the last sent frame.

Fixes #49