### PR TITLE
Assign RPC promise callbacks before sending frame

### DIFF
--- a/src/amqp-channel.ts
+++ b/src/amqp-channel.ts
@@ -743,11 +743,9 @@ export class AMQPChannel {
   private sendRpc(frame: AMQPView, frameSize: number): Promise<any> {
     return new Promise((resolve, reject) => {
       this.rpcQueue = this.rpcQueue.then(() => {
+        this.resolveRPC = resolve
+        this.rejectRPC = reject
         this.connection.send(new Uint8Array(frame.buffer, 0, frameSize))
-          .then(() => {
-            this.resolveRPC = resolve
-            this.rejectRPC = reject
-          })
           .catch(reject)
       })
     })


### PR DESCRIPTION
To prevent a race condition where the response frame is receivied before the promise assignment.

Resolves #130