### PR TITLE
Fix the `has an onerror callback` websocket test

### DIFF
--- a/test-browser/websocket.ts
+++ b/test-browser/websocket.ts
@@ -595,9 +595,9 @@ test("has an onerror callback", async () => {
   const conn = await amqp.connect()
   const ch = await conn.channel()
   let errMessage: string | null = null
-  conn.onerror = vi.fn((err) => errMessage = err.message)
+  ch.onerror = vi.fn((reason) => errMessage = reason)
   await expect(ch.exchangeDeclare("none", "none")).rejects.toThrow()
-  expect(conn.onerror).toBeCalled()
+  expect(ch.onerror).toBeCalled()
   expect(errMessage).toMatch(/invalid exchange type/)
 })
 


### PR DESCRIPTION
This is how the test in `test/test.ts` looks.

https://github.com/cloudamqp/amqp-client.js/blob/48a76b27343b94aa665cf029ff789d068c0921b6/test/test.ts#L596-L605

I think this is the intention. Right @ngbrown?  

Somehow we missed it in https://github.com/cloudamqp/amqp-client.js/pull/71

Before this change, the test failed like this

```
 FAIL  |test-browser| test-browser/websocket.ts > has an onerror callback
AssertionError: expected "spy" to be called at least once
 ❯ Proxy.methodWrapper ../../../../node_modules/.vite/deps/vitest___chai.js:1050:29
 ❯ test-browser/websocket.ts:600:23
    598|   conn.onerror = vi.fn((err) => errMessage = err.message)
    599|   await expect(ch.exchangeDeclare("none", "none")).rejects.toThrow()
    600|   expect(conn.onerror).toBeCalled()
       |                       ^
    601|   expect(errMessage).toMatch(/invalid exchange type/)
    602| })
```