### PR TITLE
fix: remove unecessary as casting

### DIFF
--- a/src/amqp-channel.ts
+++ b/src/amqp-channel.ts
@@ -51,7 +51,7 @@ export class AMQPChannel {
   /**
    * Declare a queue and return an AMQPQueue instance.
    */
-  queue(name = "", {passive = false, durable = name !== "", autoDelete = name === "", exclusive = name === ""} = {} as QueueParams, args = {}): Promise<AMQPQueue> {
+  queue(name = "", { passive = false, durable = name !== "", autoDelete = name === "", exclusive = name === "" }: QueueParams = {}, args = {}): Promise<AMQPQueue> {
     return new Promise((resolve, reject) => {
       this.queueDeclare(name, {passive, durable, autoDelete, exclusive}, args)
         .then(({name}) => resolve(new AMQPQueue(this, name)))
@@ -446,7 +446,7 @@ export class AMQPChannel {
    * @param args - optional custom queue arguments
    * @return fulfilled when confirmed by the server
    */
-  queueDeclare(name = "", { passive = false, durable = name !== "", autoDelete = name === "", exclusive = name === "" } = {} as QueueParams, args = {}): Promise<QueueOk> {
+  queueDeclare(name = "", { passive = false, durable = name !== "", autoDelete = name === "", exclusive = name === "" }: QueueParams = {}, args = {}): Promise<QueueOk> {
     if (this.closed) return this.rejectClosed()
     const noWait = false
     let j = 0
@@ -591,7 +591,7 @@ export class AMQPChannel {
    * @param args - optional arguments
    * @return Fulfilled when the exchange is created or if it already exists
    */
-  exchangeDeclare(name: string, type: ExchangeType, { passive = false, durable = true, autoDelete = false, internal = false } = {} as ExchangeParams, args = {}): Promise<void> {
+  exchangeDeclare(name: string, type: ExchangeType, { passive = false, durable = true, autoDelete = false, internal = false }: ExchangeParams = {}, args = {}): Promise<void> {
     const noWait = false
     let j = 0
     const frame = new AMQPView(new ArrayBuffer(4096))

--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -63,9 +63,9 @@ export class AMQPQueue {
    * @param [params.args={}] - custom arguments
    * @param {function(AMQPMessage) : void} callback - Function to be called for each received message
    */
-  subscribe({ noAck = true, exclusive = false, tag = "", args = {} } = {} as ConsumeParams,
-            callback: (msg: AMQPMessage) => void) : Promise<AMQPConsumer> {
-    return this.channel.basicConsume(this.name, {noAck, exclusive, tag, args}, callback)
+  subscribe({ noAck = true, exclusive = false, tag = "", args = {} }: ConsumeParams = {},
+    callback: (msg: AMQPMessage) => void): Promise<AMQPConsumer> {
+    return this.channel.basicConsume(this.name, { noAck, exclusive, tag, args }, callback)
   }
 
   /**

--- a/src/amqp-view.ts
+++ b/src/amqp-view.ts
@@ -281,7 +281,7 @@ export class AMQPView extends DataView<Uint8Array['buffer']>  {
     switch (typeof field) {
       case "string":
         this.setUint8(i, 'S'.charCodeAt(0)); i += 1
-        i += this.setLongString(i, field as string, littleEndian)
+        i += this.setLongString(i, field, littleEndian)
         break
       case "boolean":
         this.setUint8(i, 't'.charCodeAt(0)); i += 1
@@ -289,7 +289,7 @@ export class AMQPView extends DataView<Uint8Array['buffer']>  {
         break
       case "bigint":
         this.setUint8(i, 'l'.charCodeAt(0)); i += 1
-        this.setBigInt64(i, field as bigint, littleEndian); i += 8
+        this.setBigInt64(i, field, littleEndian); i += 8
         break
       case "number":
         if (Number.isInteger(field)) {


### PR DESCRIPTION
This pull request focuses on improving type safety and code clarity by refining TypeScript type annotations and removing unnecessary type assertions. The changes primarily affect methods in the `AMQPChannel`, `AMQPQueue`, and `AMQPView` classes.

### TypeScript type safety improvements:

* [`src/amqp-channel.ts`](diffhunk://#diff-663dae8bbcf9718ab8a7ac19e5296ecafa56b738b6c2d2e76a3214b24048b5daL54-R54): Updated the `queue`, `queueDeclare`, and `exchangeDeclare` methods to use explicit type annotations for default parameter values, replacing type assertions with inline type definitions for cleaner and safer code. [[1]](diffhunk://#diff-663dae8bbcf9718ab8a7ac19e5296ecafa56b738b6c2d2e76a3214b24048b5daL54-R54) [[2]](diffhunk://#diff-663dae8bbcf9718ab8a7ac19e5296ecafa56b738b6c2d2e76a3214b24048b5daL449-R449) [[3]](diffhunk://#diff-663dae8bbcf9718ab8a7ac19e5296ecafa56b738b6c2d2e76a3214b24048b5daL594-R594)

* [`src/amqp-queue.ts`](diffhunk://#diff-b15f45810b998861bb43b154b0687f94ab93d7329f4d5706602ad1dae7f04646L66-R66): Refined the `subscribe` method parameters by replacing the type assertion with an inline type definition, ensuring consistency with other method signatures.

* [`src/amqp-view.ts`](diffhunk://#diff-6bc701e77a826c1dc6768b263ef4145eb417229a781f82478a5831b95a036011L284-R292): Removed redundant type assertions in the `setLongString` and `setBigInt64` method calls, relying on TypeScript's type inference for improved readability and maintainability.