### PR TITLE
Add AsyncGenerator support to subscribe() for improved DX

### DIFF
--- a/src/amqp-consumer.ts
+++ b/src/amqp-consumer.ts
@@ -9,8 +9,8 @@ export class AMQPConsumer {
   readonly channel: AMQPChannel
   readonly tag: string
   readonly onMessage: (msg: AMQPMessage) => void | Promise<void>
-  private closed = false
-  private closedError?: Error
+  protected closed = false
+  protected closedError?: Error
   private resolveWait?: (value: void) => void
   private rejectWait?: (err: Error) => void
   private timeoutId?: ReturnType<typeof setTimeout>
@@ -64,6 +64,74 @@ export class AMQPConsumer {
       if (this.rejectWait) this.rejectWait(err)
     } else {
       if (this.resolveWait) this.resolveWait()
+    }
+  }
+}
+
+export class AMQPGeneratorConsumer extends AMQPConsumer {
+  private messageQueue: AMQPMessage[] = []
+  private messageResolver: ((msg: AMQPMessage) => void) | null = null
+  private _generator?: AsyncGenerator<AMQPMessage, void, undefined>
+
+  constructor(channel: AMQPChannel, tag: string) {
+    super(channel, tag, (msg: AMQPMessage) => {
+      // Feed messages to the generator queue
+      if (this.messageResolver) {
+        this.messageResolver(msg)
+        this.messageResolver = null
+      } else if (this.messageQueue) {
+        this.messageQueue.push(msg)
+      }
+    })
+  }
+
+  /**
+   * Get an AsyncGenerator for consuming messages.
+   * @return An AsyncGenerator that yields messages
+   */
+  get messages(): AsyncGenerator<AMQPMessage, void, undefined> {
+    if (this._generator) {
+      return this._generator
+    }
+
+    this._generator = this.generateMessages()
+    return this._generator
+  }
+
+  private async *generateMessages(): AsyncGenerator<AMQPMessage, void, undefined> {
+    try {
+      while (!this.closedError && !this.closed) {
+        if (this.messageQueue.length > 0) {
+          const msg = this.messageQueue.shift()!
+          yield msg
+        } else {
+          const msg = await new Promise<AMQPMessage>((resolve) => {
+            this.messageResolver = resolve
+          })
+          if (this.closedError || this.closed) break
+          yield msg
+        }
+      }
+      if (this.closedError) throw this.closedError
+    } finally {
+      // Clean up: cancel consumer when generator is done
+      try {
+        await this.cancel()
+      } catch {
+        // Ignore errors during cleanup
+      }
+    }
+  }
+
+  override setClosed(err?: Error): void {
+    super.setClosed(err)
+    // Wake up the generator if it's waiting
+    if (this.messageResolver) {
+      const resolver = this.messageResolver
+      this.messageResolver = null
+      // Resolve the promise with a sentinel value
+      // The generator will check closedError/closed immediately and break without yielding
+      resolver(undefined as unknown as AMQPMessage)
     }
   }
 }


### PR DESCRIPTION
Extends queue.subscribe() to support AsyncGenerator-based message consumption via consumer.messages property when no callback is provided.

Benefits:
- Natural iteration with for await...of loops
- Automatic consumer cancellation on loop exit
- Better backpressure control
- Access to consumer methods (wait, cancel, tag)

Implementation:
- New AMQPGeneratorConsumer subclass handles generator logic
- subscribe() overloads: with callback returns AMQPConsumer, without callback returns AMQPGeneratorConsumer
- consumer.messages property (not method) for cleaner syntax
- Reuses existing callback infrastructure for message delivery

Fixes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)