### PR TITLE
Fix: consumer.wait() resolves cleanly on client-initiated close

### DIFF
--- a/src/amqp-channel.ts
+++ b/src/amqp-channel.ts
@@ -834,7 +834,9 @@ export class AMQPChannel {
     err ||= new Error("Connection closed by client")
     if (!this.closed) {
       this.closed = true
-      this.consumers.forEach((consumer) => consumer.setClosed(err))
+      // On client-initiated close, consumers resolve cleanly (no error).
+      // Only propagate the error when the server closed the channel/connection.
+      this.consumers.forEach((consumer) => consumer.setClosed(closedByServer ? err : undefined))
       this.consumers.clear()
 
       // Reject all pending RPC callbacks


### PR DESCRIPTION
## Problem

When `client.close()` is called, `AMQPChannel.setClosed()` passes an error to all consumers — even though the close was client-initiated and graceful. This causes `consumer.wait()` to reject with `"Connection closed by client"` instead of resolving.

Callers are then forced to catch this error and distinguish it from actual failures:

```ts
try {
  await consumer.wait()
} catch (err) {
  // Is this a real error, or just our own close()?
  if (err.message === "Connection closed by client") return
  throw err
}
```

This is especially problematic during graceful shutdown, where there's a race between when `isShuttingDown` is set and when the TCP Close-Ok event fires, making reliable detection timing-dependent.

## Fix

In `setClosed()`, only pass the error to consumers when the server closed the channel/connection. For client-initiated close (`closedByServer === false`), pass `undefined` so `consumer.wait()` resolves normally.

RPC callbacks and unconfirmed publishes still reject — those represent in-flight operations that didn't complete and callers need to know about.

## Before / After

```ts
// Before: always rejects
await consumer.wait()  // throws Error("Connection closed by client")

// After: resolves cleanly on client.close(), rejects on server close
await consumer.wait()  // resolves
```