### PR TITLE
Test against non-EoL versions of Node.js

### DIFF
--- a/.github/workflows/lavinmq.yml
+++ b/.github/workflows/lavinmq.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 23.x, 24.x]
+        node-version: [20.x, 22.x, 24.x, 25.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/rabbitmq.yml
+++ b/.github/workflows/rabbitmq.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
+        node-version: [20.x, 22.x, 24.x, 25.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
https://nodejs.org/en/about/previous-releases

Wasn't sure if we should add 25, it will likely go EoL in a month, but can be nice to know about potential incompatibilities with the upcoming 26 version.