### PR TITLE
Use random string for unknown exchange type tests

### DIFF
--- a/test/test.ts
+++ b/test/test.ts
@@ -422,12 +422,14 @@ test("can handle nacks on confirm channel", async () => {
   await expect(ch.basicPublish("", q.name, "body")).rejects.toThrow("Message rejected")
 })
 
-test("throws on invalid exchange type", async () => {
+test("throws on unknown exchange type", async () => {
   const amqp = getNewClient()
   const conn = await amqp.connect()
   const ch = await conn.channel()
   const name = "test" + Math.random()
-  await expect(ch.exchangeDeclare(name, "none")).rejects.toThrow(/invalid exchange type/)
+  const unknownType = "unknowntype" + Math.random().toString(36).slice(2)
+  // LavinMQ < 2.8.0 reports "invalid exchange type"; newer LavinMQ and RabbitMQ report "unknown exchange type"
+  await expect(ch.exchangeDeclare(name, unknownType)).rejects.toThrow(/(unknown|invalid) exchange type/)
 })
 
 test("can declare an exchange", async () => {
@@ -756,9 +758,11 @@ test("has an onerror callback", async () => {
   const ch = await conn.channel()
   let errMessage: string | null = null
   ch.onerror = vi.fn((reason) => (errMessage = reason))
-  await expect(ch.exchangeDeclare("none", "none")).rejects.toThrow()
+  const unknownType = "unknowntype" + Math.random().toString(36).slice(2)
+  await expect(ch.exchangeDeclare("name" + Math.random(), unknownType)).rejects.toThrow()
   expect(ch.onerror).toBeCalled()
-  expect(errMessage).toMatch(/invalid exchange type/)
+  // LavinMQ < 2.8.0 reports "invalid exchange type"; newer LavinMQ and RabbitMQ report "unknown exchange type"
+  expect(errMessage).toMatch(/(unknown|invalid) exchange type/)
 })
 
 test("onerror is not called when conn is closed by client", async () => {


### PR DESCRIPTION
Previously, the tests passed "none" as the exchange type and asserted on the "invalid exchange type" error. In RabbitMQ, that path only fires in `rabbit_exchange:check_type/1` when the type is a known atom whose module lookup fails — "none" happens to already be interned as an atom in the VM, so `binary_to_existing_atom/1` succeeds and the module lookup is what fails.

A random string, on the other hand, exercises the other branch: `binary_to_existing_atom/1` returns `{error, not_found}` in `rabbit_registry:binary_to_type/1`, and the broker replies with "unknown exchange type '<name>'".

However, the change to random strings breaks compatibility with LavinMQ < 2.8.0 (2.8.0 will include https://github.com/cloudamqp/lavinmq/pull/1811), temporarily broaden the regex to allow for both types of messages.
