### PR TITLE
session: serialize ops channel via a mutex

### DIFF
--- a/src/amqp-exchange.ts
+++ b/src/amqp-exchange.ts
@@ -65,8 +65,14 @@ export class AMQPExchange<
       defaults,
     )
     if (encoded.properties.deliveryMode === undefined) encoded.properties.deliveryMode = 2
-    const ch = confirm ? await this.session.getConfirmChannel() : await this.session.getOpsChannel()
-    await ch.basicPublish(this.name, routingKey, encoded.body, encoded.properties)
+    if (confirm) {
+      const ch = await this.session.getConfirmChannel()
+      await ch.basicPublish(this.name, routingKey, encoded.body, encoded.properties)
+    } else {
+      await this.session.withOpsChannel(async (ch) => {
+        await ch.basicPublish(this.name, routingKey, encoded.body, encoded.properties)
+      })
+    }
     return this
   }
 
@@ -81,8 +87,7 @@ export class AMQPExchange<
     args: Record<string, unknown> = {},
   ): Promise<AMQPExchange<P, C, KP, KC>> {
     const sourceName = typeof source === "string" ? source : source.name
-    const ch = await this.session.getOpsChannel()
-    await ch.exchangeBind(this.name, sourceName, routingKey, args)
+    await this.session.withOpsChannel((ch) => ch.exchangeBind(this.name, sourceName, routingKey, args))
     return this
   }
 
@@ -97,8 +102,7 @@ export class AMQPExchange<
     args: Record<string, unknown> = {},
   ): Promise<AMQPExchange<P, C, KP, KC>> {
     const sourceName = typeof source === "string" ? source : source.name
-    const ch = await this.session.getOpsChannel()
-    await ch.exchangeUnbind(this.name, sourceName, routingKey, args)
+    await this.session.withOpsChannel((ch) => ch.exchangeUnbind(this.name, sourceName, routingKey, args))
     return this
   }
 
@@ -107,7 +111,6 @@ export class AMQPExchange<
    * @param [params.ifUnused=false] - only delete if the exchange has no bindings
    */
   async delete(params?: { ifUnused?: boolean }): Promise<void> {
-    const ch = await this.session.getOpsChannel()
-    await ch.exchangeDelete(this.name, params)
+    await this.session.withOpsChannel((ch) => ch.exchangeDelete(this.name, params))
   }
 }

--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -151,14 +151,15 @@ export class AMQPQueue<
    * @param [params.noAck=true] - automatically acknowledge on delivery
    */
   async get(params?: { noAck?: boolean }): Promise<AMQPMessage<P> | null> {
-    return this.session.withOpsChannel(async (ch) => {
-      const msg = await ch.basicGet(this.name, params)
-      if (!msg) return null
-      if (this.session.parsers || this.session.coders) {
-        await decodeMessage(msg, this.session.parsers ?? {}, this.session.coders ?? {})
-      }
-      return msg as AMQPMessage<P>
-    })
+    // Hold the mutex only for the RPC. Decoding/decompression doesn't touch
+    // the channel and can be expensive (gzip etc.), so let other ops-channel
+    // work proceed in parallel with it.
+    const msg = await this.session.withOpsChannel((ch) => ch.basicGet(this.name, params))
+    if (!msg) return null
+    if (this.session.parsers || this.session.coders) {
+      await decodeMessage(msg, this.session.parsers ?? {}, this.session.coders ?? {})
+    }
+    return msg as AMQPMessage<P>
   }
 
   /**

--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -85,8 +85,14 @@ export class AMQPQueue<
       defaults,
     )
     if (encoded.properties.deliveryMode === undefined) encoded.properties.deliveryMode = 2
-    const ch = confirm ? await this.session.getConfirmChannel() : await this.session.getOpsChannel()
-    await ch.basicPublish("", this.name, encoded.body, encoded.properties)
+    if (confirm) {
+      const ch = await this.session.getConfirmChannel()
+      await ch.basicPublish("", this.name, encoded.body, encoded.properties)
+    } else {
+      await this.session.withOpsChannel(async (ch) => {
+        await ch.basicPublish("", this.name, encoded.body, encoded.properties)
+      })
+    }
     return this
   }
 
@@ -145,13 +151,14 @@ export class AMQPQueue<
    * @param [params.noAck=true] - automatically acknowledge on delivery
    */
   async get(params?: { noAck?: boolean }): Promise<AMQPMessage<P> | null> {
-    const ch = await this.session.getOpsChannel()
-    const msg = await ch.basicGet(this.name, params)
-    if (!msg) return null
-    if (this.session.parsers || this.session.coders) {
-      await decodeMessage(msg, this.session.parsers ?? {}, this.session.coders ?? {})
-    }
-    return msg as AMQPMessage<P>
+    return this.session.withOpsChannel(async (ch) => {
+      const msg = await ch.basicGet(this.name, params)
+      if (!msg) return null
+      if (this.session.parsers || this.session.coders) {
+        await decodeMessage(msg, this.session.parsers ?? {}, this.session.coders ?? {})
+      }
+      return msg as AMQPMessage<P>
+    })
   }
 
   /**
@@ -164,8 +171,7 @@ export class AMQPQueue<
     args: Record<string, unknown> = {},
   ): Promise<AMQPQueue<P, C, KP, KC>> {
     const exchangeName = typeof exchange === "string" ? exchange : exchange.name
-    const ch = await this.session.getOpsChannel()
-    await ch.queueBind(this.name, exchangeName, routingKey, args)
+    await this.session.withOpsChannel((ch) => ch.queueBind(this.name, exchangeName, routingKey, args))
     return this
   }
 
@@ -179,15 +185,13 @@ export class AMQPQueue<
     args: Record<string, unknown> = {},
   ): Promise<AMQPQueue<P, C, KP, KC>> {
     const exchangeName = typeof exchange === "string" ? exchange : exchange.name
-    const ch = await this.session.getOpsChannel()
-    await ch.queueUnbind(this.name, exchangeName, routingKey, args)
+    await this.session.withOpsChannel((ch) => ch.queueUnbind(this.name, exchangeName, routingKey, args))
     return this
   }
 
   /** Purge all messages from this queue. */
   async purge(): Promise<MessageCount> {
-    const ch = await this.session.getOpsChannel()
-    return ch.queuePurge(this.name)
+    return this.session.withOpsChannel((ch) => ch.queuePurge(this.name))
   }
 
   /**
@@ -196,8 +200,7 @@ export class AMQPQueue<
    * @param [params.ifEmpty=false] - only delete if the queue is empty
    */
   async delete(params?: { ifUnused?: boolean; ifEmpty?: boolean }): Promise<MessageCount> {
-    const ch = await this.session.getOpsChannel()
-    return ch.queueDelete(this.name, params)
+    return this.session.withOpsChannel((ch) => ch.queueDelete(this.name, params))
   }
 
   /**

--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -232,13 +232,22 @@ export class AMQPSession<
    * @param [args] - optional queue arguments (e.g. `x-message-ttl`)
    */
   async queue(name: string, params?: QueueParams, args?: Record<string, unknown>): Promise<AMQPQueue<P, C, KP, KC>> {
-    const ch = await this.getOpsChannel()
-    const res = await ch.queueDeclare(name, params, args)
-    const existing = this.queues.get(res.name)
-    if (existing) return existing
-    const q = new AMQPQueue<P, C, KP, KC>(this, res.name)
-    this.queues.set(res.name, q)
-    return q
+    // Passive declares throw NOT_FOUND when the queue is missing, which the
+    // broker signals by closing the channel. Routing passive declares to a
+    // dedicated short-lived channel keeps that side effect from tearing down
+    // the session's shared ops channel and disrupting unrelated work.
+    const passive = params?.passive === true
+    const ch = passive ? await this.openChannel() : await this.getOpsChannel()
+    try {
+      const res = await ch.queueDeclare(name, params, args)
+      const existing = this.queues.get(res.name)
+      if (existing) return existing
+      const q = new AMQPQueue<P, C, KP, KC>(this, res.name)
+      this.queues.set(res.name, q)
+      return q
+    } finally {
+      if (passive && !ch.closed) await ch.close().catch(() => {})
+    }
   }
 
   /**
@@ -254,9 +263,17 @@ export class AMQPSession<
     params?: ExchangeParams,
     args?: Record<string, unknown>,
   ): Promise<AMQPExchange<P, C, KP, KC>> {
-    const ch = await this.getOpsChannel()
-    await ch.exchangeDeclare(name, type, params, args)
-    return new AMQPExchange<P, C, KP, KC>(this, name)
+    // Passive declares throw NOT_FOUND when the exchange is missing, which
+    // the broker signals by closing the channel. Use a dedicated short-lived
+    // channel so the session's shared ops channel survives.
+    const passive = params?.passive === true
+    const ch = passive ? await this.openChannel() : await this.getOpsChannel()
+    try {
+      await ch.exchangeDeclare(name, type, params, args)
+      return new AMQPExchange<P, C, KP, KC>(this, name)
+    } finally {
+      if (passive && !ch.closed) await ch.close().catch(() => {})
+    }
   }
 
   /**

--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -195,6 +195,34 @@ export class AMQPSession<
     return this.opsChannelPromise
   }
 
+  // Serializes operations on the shared ops channel. AMQP channel-level
+  // errors (NOT_FOUND on a passive declare, PRECONDITION_FAILED on
+  // mismatched declare args, exclusive conflicts, etc.) close the channel.
+  // Without a mutex, a concurrent RPC in flight on the same channel fails
+  // with a generic "channel closed" error that has nothing to do with what
+  // it was doing. Mirrors the Ruby client's single-connection invariant —
+  // throughput-wise this serializes declares + bind/unbind/purge/delete +
+  // basicGet + unconfirmed publishes; confirmed publishes (confirm channel)
+  // and consumers (dedicated channels via openChannel) are unaffected.
+  private opsLock: Promise<unknown> = Promise.resolve()
+
+  /**
+   * Run `fn` with exclusive access to the shared ops channel. Each caller
+   * waits for the previous one to settle, so a channel-closing RPC error
+   * never disrupts an unrelated op in flight.
+   * @internal
+   */
+  withOpsChannel<T>(fn: (ch: AMQPChannel) => Promise<T>): Promise<T> {
+    const result = this.opsLock.then(async () => {
+      const ch = await this.getOpsChannel()
+      return fn(ch)
+    })
+    // Chain even on rejection so a failing op doesn't deadlock subsequent
+    // callers. Errors propagate to the caller via the returned promise.
+    this.opsLock = result.catch(() => {})
+    return result
+  }
+
   /**
    * Return the shared confirm channel, opening and enabling publish confirms if needed.
    * Used by queue/exchange handles for confirmed publishes.
@@ -232,22 +260,14 @@ export class AMQPSession<
    * @param [args] - optional queue arguments (e.g. `x-message-ttl`)
    */
   async queue(name: string, params?: QueueParams, args?: Record<string, unknown>): Promise<AMQPQueue<P, C, KP, KC>> {
-    // Passive declares throw NOT_FOUND when the queue is missing, which the
-    // broker signals by closing the channel. Routing passive declares to a
-    // dedicated short-lived channel keeps that side effect from tearing down
-    // the session's shared ops channel and disrupting unrelated work.
-    const passive = params?.passive === true
-    const ch = passive ? await this.openChannel() : await this.getOpsChannel()
-    try {
+    return this.withOpsChannel(async (ch) => {
       const res = await ch.queueDeclare(name, params, args)
       const existing = this.queues.get(res.name)
       if (existing) return existing
       const q = new AMQPQueue<P, C, KP, KC>(this, res.name)
       this.queues.set(res.name, q)
       return q
-    } finally {
-      if (passive && !ch.closed) await ch.close().catch(() => {})
-    }
+    })
   }
 
   /**
@@ -263,17 +283,10 @@ export class AMQPSession<
     params?: ExchangeParams,
     args?: Record<string, unknown>,
   ): Promise<AMQPExchange<P, C, KP, KC>> {
-    // Passive declares throw NOT_FOUND when the exchange is missing, which
-    // the broker signals by closing the channel. Use a dedicated short-lived
-    // channel so the session's shared ops channel survives.
-    const passive = params?.passive === true
-    const ch = passive ? await this.openChannel() : await this.getOpsChannel()
-    try {
+    return this.withOpsChannel(async (ch) => {
       await ch.exchangeDeclare(name, type, params, args)
       return new AMQPExchange<P, C, KP, KC>(this, name)
-    } finally {
-      if (passive && !ch.closed) await ch.close().catch(() => {})
-    }
+    })
   }
 
   /**

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -962,12 +962,11 @@ test("get() returns AMQPMessage with body", () =>
     expect(msg!.body).toBeInstanceOf(Uint8Array)
   }))
 
-test("session.queue passive NOT_FOUND doesn't break concurrent ops on ops channel", () =>
+test("ops channel: passive NOT_FOUND doesn't disrupt concurrent declares", () =>
   withSession(async (session) => {
-    // Fire a passive-against-missing and a normal declare concurrently. They
-    // both go through getOpsChannel() — without dedicated routing for passive,
-    // the broker's NOT_FOUND close on the passive RPC also fails the
-    // concurrent normal declare with "channel closed".
+    // Without the ops-channel mutex, the broker's NOT_FOUND close on the
+    // passive RPC would also fail concurrent declares in flight on the
+    // shared ops channel with a generic "channel closed" error.
     const okName = "test-passive-concurrent-" + Math.random()
     const results = await Promise.allSettled([
       session.queue("nope-" + Math.random(), { passive: true }),
@@ -981,12 +980,19 @@ test("session.queue passive NOT_FOUND doesn't break concurrent ops on ops channe
     expect(results[1]?.status).toBe("fulfilled")
   }))
 
-test("session.exchange passive NOT_FOUND doesn't break concurrent ops on ops channel", () =>
+test("ops channel: PRECONDITION_FAILED on mismatched declare doesn't disrupt siblings", () =>
   withSession(async (session) => {
-    const okName = "test-passive-ex-concurrent-" + Math.random()
+    // Declare with one set of args, then attempt a conflicting declare
+    // concurrently with an unrelated declare. The conflict closes the
+    // channel — without the mutex the sibling declare fails too.
+    const name = "test-precondition-" + Math.random()
+    await session.queue(name, { durable: false, autoDelete: true })
+
+    const okName = "test-precondition-sibling-" + Math.random()
     const results = await Promise.allSettled([
-      session.exchange("nope-ex-" + Math.random(), "direct", { passive: true }),
-      session.directExchange(okName, { durable: false, autoDelete: true }),
+      // Re-declare with conflicting args → PRECONDITION_FAILED → channel close.
+      session.queue(name, { durable: true }),
+      session.queue(okName, { durable: false, autoDelete: true }),
     ])
 
     expect(results[0]?.status).toBe("rejected")

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -961,3 +961,34 @@ test("get() returns AMQPMessage with body", () =>
     expect(msg).toBeInstanceOf(AMQPMessage)
     expect(msg!.body).toBeInstanceOf(Uint8Array)
   }))
+
+test("session.queue passive NOT_FOUND doesn't break concurrent ops on ops channel", () =>
+  withSession(async (session) => {
+    // Fire a passive-against-missing and a normal declare concurrently. They
+    // both go through getOpsChannel() — without dedicated routing for passive,
+    // the broker's NOT_FOUND close on the passive RPC also fails the
+    // concurrent normal declare with "channel closed".
+    const okName = "test-passive-concurrent-" + Math.random()
+    const results = await Promise.allSettled([
+      session.queue("nope-" + Math.random(), { passive: true }),
+      session.queue(okName, { durable: false, autoDelete: true }),
+    ])
+
+    expect(results[0]?.status).toBe("rejected")
+    if (results[0]?.status === "rejected") {
+      expect(String(results[0].reason)).toMatch(/NOT[_-]?FOUND/i)
+    }
+    expect(results[1]?.status).toBe("fulfilled")
+  }))
+
+test("session.exchange passive NOT_FOUND doesn't break concurrent ops on ops channel", () =>
+  withSession(async (session) => {
+    const okName = "test-passive-ex-concurrent-" + Math.random()
+    const results = await Promise.allSettled([
+      session.exchange("nope-ex-" + Math.random(), "direct", { passive: true }),
+      session.directExchange(okName, { durable: false, autoDelete: true }),
+    ])
+
+    expect(results[0]?.status).toBe("rejected")
+    expect(results[1]?.status).toBe("fulfilled")
+  }))


### PR DESCRIPTION
## Background

`AMQPSession` shares one ops channel for declares, binds, purges, deletes, basicGet, and unconfirmed publishes. AMQP channel-level errors (NOT_FOUND on a passive declare, PRECONDITION_FAILED on mismatched declare args, RESOURCE_LOCKED on exclusive conflicts, ACCESS_REFUSED, etc.) close the channel. With concurrent ops in flight on that channel, the broker's close frame fails not only the caller that triggered it but every sibling RPC too — with a generic \"channel closed\" error that has nothing to do with what they were doing.

## Summary

Adopt the Ruby client's invariant: serialize all ops-channel work via a chained-promise mutex.

- New `AMQPSession.withOpsChannel(fn)` acquires the lock, runs `fn(ch)` on the shared ops channel, releases on settle (success or failure, so a failing op doesn't deadlock the queue).
- `session.queue()` and `session.exchange()` route through it.
- `AMQPQueue.{get, bind, unbind, purge, delete}` and unconfirmed `AMQPQueue.publish` use it.
- `AMQPExchange.{bind, unbind, delete}` and unconfirmed `AMQPExchange.publish` use it.
- Confirmed publishes (separate confirm channel) and consumers (dedicated channels via `openChannel`) are unaffected.

## Design notes

- **Ruby client (`amqp-client.rb`) precedent**: uses `SizedQueue.new(1)` to serialize all high-level ops on one connection + hardcoded channel ID 1 for everything. The bug literally can't manifest because nothing runs concurrently. We get the same robustness in JS by gating just the shared ops channel.
- **Tradeoff**: declares + binds + basicGet + unconfirmed publishes serialize at the JS layer instead of pipelining on the wire. For most users this is invisible; for code that issues per-request declares the wall-clock cost is `n_ops * rtt` instead of `~1 rtt`. Confirmed publishes and consumer setup keep their parallelism.
- **Alternative considered**: isolate just passive declares to dedicated channels (this PR's first commit). Rejected because PRECONDITION_FAILED, RESOURCE_LOCKED, and other channel-closing errors have the same failure mode — a general fix is simpler than a growing list of \"this op also needs isolation.\"

## Test plan

- [x] `npm run format:check` clean
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npx vitest run test/amqp-session.ts` — 59/59 pass (incl. 2 new regression tests)
- [x] Verified both new tests fail on the parent commit and pass with the mutex
  - `passive NOT_FOUND doesn't disrupt concurrent declares`
  - `PRECONDITION_FAILED on mismatched declare doesn't disrupt siblings`