### PR TITLE
subscription: cancel() is best-effort, never throws

### DIFF
--- a/src/amqp-subscription.ts
+++ b/src/amqp-subscription.ts
@@ -50,11 +50,21 @@ export class AMQPSubscription {
 
   /**
    * Cancel the subscription and remove it from session auto-recovery.
-   * Safe to call on a closed channel.
+   *
+   * Best-effort: never throws on wire-level failures. If the channel
+   * dropped mid-cancel or the broker is gone, the consumer is already
+   * effectively dead — there's nothing for the caller to recover from,
+   * so swallowing the error means call sites don't need `.catch(() => {})`
+   * boilerplate around every cancel.
    */
   async cancel(): Promise<void> {
     this.onCancel?.()
-    await this.consumer.cancel()
+    try {
+      await this.consumer.cancel()
+    } catch {
+      // Channel/connection closed before basic.cancel could complete —
+      // the consumer is gone either way.
+    }
   }
 
   /**

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -998,3 +998,23 @@ test("ops channel: PRECONDITION_FAILED on mismatched declare doesn't disrupt sib
     expect(results[0]?.status).toBe("rejected")
     expect(results[1]?.status).toBe("fulfilled")
   }))
+
+test("subscription.cancel() swallows underlying consumer errors", () =>
+  withSession(async (session) => {
+    const q = await session.queue("test-cancel-throws-" + Math.random(), {
+      durable: false,
+      autoDelete: true,
+    })
+    const sub = await q.subscribe({ noAck: true }, () => {})
+
+    // Simulate the broker/channel dropping mid-cancel: stub the consumer's
+    // cancel to reject. Real-world equivalents include channel close
+    // racing with the basic.cancel RPC, broker errors during cancel, or
+    // the connection going away between the closed-check and the wire.
+    // Without the best-effort guard in AMQPSubscription.cancel, the
+    // rejection bubbles up and forces every caller to `.catch(() => {})`.
+    const internal = sub as unknown as { consumer: { cancel(): Promise<unknown> } }
+    internal.consumer.cancel = () => Promise.reject(new Error("simulated cancel failure"))
+
+    await expect(sub.cancel()).resolves.toBeUndefined()
+  }))


### PR DESCRIPTION
## Background

Every caller of `AMQPSubscription.cancel()` wraps it in `.catch(() => {})`. The pattern shows up all over the place. The reason is uniform: by the time you're cancelling, the channel might already be torn down (worker shutdown), the connection might be dropping (mid-reconnect), or the broker might be returning an error frame. The caller has no recovery option — the consumer is gone either way.

## Summary

Swallow wire-level errors in `AMQPSubscription.cancel()` so call sites don't have to. The contract becomes \"cancel is a best-effort cleanup; never throws on the happy path.\"

Triggers we want to swallow:
- Channel closes between the existing closed-check and basic.cancel reaching the wire
- Broker returns an error frame during cancel
- Connection drops mid-RPC, rejecting every pending channel operation

In every case the consumer is effectively cancelled (or never existed) — there's nothing for the caller to recover from.

The `onCancel` callback still fires synchronously (so session-recovery bookkeeping runs), and `AMQPGeneratorSubscription`'s `stopped`/`consumerReady` cleanup still runs before the swallow. The change is purely \"don't propagate the basic.cancel rejection upward.\"

## Test plan

- [x] `npm run format:check` clean
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npx vitest run test/amqp-session.ts` — 60/60 pass, including the new regression test
- [x] Verified the new test fails on the parent commit and passes with the change

## Follow-up in 84bot

When this lands, 84bot drops the seven `.catch(() => {})` call sites — see 84codes/84bot#336 for the wait-for-upstream comment thread.