### PR TITLE
v2 API polish: options bag + mockable interfaces

### DIFF
--- a/src/amqp-mockable.ts
+++ b/src/amqp-mockable.ts
@@ -1,0 +1,64 @@
+/**
+ * Narrow structural interfaces for the high-level session/queue/exchange
+ * surface. Use these in tests to declare typed mocks without having to
+ * implement the full {@link AMQPSession} class (which carries private
+ * fields, internal channels, reconnect state, etc).
+ *
+ * The real classes are structurally assignable to these — `AMQPSession`
+ * satisfies `AMQPSessionLike` — so application code can keep using the
+ * concrete classes while tests substitute lightweight fakes.
+ *
+ * @example
+ * ```ts
+ * import type { AMQPSessionLike, AMQPQueueLike } from "@cloudamqp/amqp-client"
+ *
+ * class FakeSession implements AMQPSessionLike {
+ *   async queue(): Promise<AMQPQueueLike> { return new FakeQueue() }
+ *   async stop(): Promise<void> {}
+ *   // ...
+ * }
+ * ```
+ */
+
+import type { AMQPMessage } from "./amqp-message.js"
+import type { ExchangeType } from "./amqp-channel.js"
+import type { ExchangeOptions, QueueOptions } from "./amqp-session.js"
+import type { AMQPProperties } from "./amqp-properties.js"
+import type { QueueSubscribeParams } from "./amqp-queue.js"
+
+/** Minimum surface a mock subscription must expose. */
+export interface AMQPSubscriptionLike {
+  cancel(): Promise<void>
+}
+
+/** Minimum surface a mock queue handle must expose. */
+export interface AMQPQueueLike {
+  readonly name: string
+  publish(body: unknown, options?: AMQPProperties & { confirm?: boolean }): Promise<unknown>
+  subscribe(
+    params: QueueSubscribeParams,
+    callback: (msg: AMQPMessage) => void | Promise<void>,
+  ): Promise<AMQPSubscriptionLike>
+  bind(exchange: string, routingKey?: string, args?: Record<string, unknown>): Promise<unknown>
+  get(params?: { noAck?: boolean }): Promise<AMQPMessage | null>
+}
+
+/** Minimum surface a mock exchange handle must expose. */
+export interface AMQPExchangeLike {
+  publish(
+    body: unknown,
+    options?: AMQPProperties & { routingKey?: string; confirm?: boolean },
+  ): Promise<unknown>
+}
+
+/** Minimum surface a mock session must expose. */
+export interface AMQPSessionLike {
+  readonly closed: boolean
+  queue(name: string, options?: QueueOptions): Promise<AMQPQueueLike>
+  exchange(name: string, type: ExchangeType, options?: ExchangeOptions): Promise<AMQPExchangeLike>
+  directExchange(name?: string, options?: ExchangeOptions): Promise<AMQPExchangeLike>
+  fanoutExchange(name?: string, options?: ExchangeOptions): Promise<AMQPExchangeLike>
+  topicExchange(name?: string, options?: ExchangeOptions): Promise<AMQPExchangeLike>
+  headersExchange(name?: string, options?: ExchangeOptions): Promise<AMQPExchangeLike>
+  stop(reason?: string): Promise<void>
+}

--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -1,5 +1,28 @@
 import type { AMQPBaseClient } from "./amqp-base-client.js"
 import type { AMQPChannel, ExchangeParams, ExchangeType, QueueParams } from "./amqp-channel.js"
+
+/**
+ * Options for {@link AMQPSession#queue}. Combines queue declaration
+ * parameters (`passive`, `durable`, `autoDelete`, `exclusive`) with the
+ * queue arguments table (`x-message-ttl`, `x-delivery-limit`, ...) so
+ * callers don't have to pass `undefined` placeholders to reach the
+ * arguments table.
+ */
+export type QueueOptions = QueueParams & {
+  /** Queue arguments table (e.g. `{ "x-delivery-limit": 3 }`). */
+  arguments?: Record<string, unknown>
+}
+
+/**
+ * Options for {@link AMQPSession#exchange} and the typed-exchange
+ * shortcuts. Combines exchange declaration parameters (`passive`,
+ * `durable`, `autoDelete`, `internal`) with the exchange arguments table
+ * (`x-delayed-type`, `alternate-exchange`, ...).
+ */
+export type ExchangeOptions = ExchangeParams & {
+  /** Exchange arguments table (e.g. `{ "x-delayed-type": "direct" }`). */
+  arguments?: Record<string, unknown>
+}
 import type { ParserMap, CoderMap, ParserRegistry, CoderRegistry } from "./amqp-codec-registry.js"
 import type { AMQPProperties } from "./amqp-properties.js"
 import type { ResolveBody } from "./amqp-publisher.js"
@@ -256,12 +279,12 @@ export class AMQPSession<
    * The returned queue's `subscribe` uses auto-recovery and `publish` waits for
    * a broker confirm.
    * @param name - queue name (use "" to let the broker generate a name)
-   * @param [params] - queue declaration parameters
-   * @param [args] - optional queue arguments (e.g. `x-message-ttl`)
+   * @param [options] - queue declaration parameters and queue arguments
    */
-  async queue(name: string, params?: QueueParams, args?: Record<string, unknown>): Promise<AMQPQueue<P, C, KP, KC>> {
+  async queue(name: string, options?: QueueOptions): Promise<AMQPQueue<P, C, KP, KC>> {
+    const { arguments: queueArguments, ...declarationParams } = options ?? {}
     return this.withOpsChannel(async (ch) => {
-      const res = await ch.queueDeclare(name, params, args)
+      const res = await ch.queueDeclare(name, declarationParams, queueArguments)
       const existing = this.queues.get(res.name)
       if (existing) return existing
       const q = new AMQPQueue<P, C, KP, KC>(this, res.name)
@@ -274,17 +297,16 @@ export class AMQPSession<
    * Declare an exchange and return a session-bound {@link AMQPExchange} handle.
    * @param name - exchange name
    * @param type - exchange type: `"direct"`, `"fanout"`, `"topic"`, `"headers"`, or a custom type
-   * @param [params] - exchange declaration parameters
-   * @param [args] - optional exchange arguments
+   * @param [options] - exchange declaration parameters and exchange arguments
    */
   async exchange(
     name: string,
     type: ExchangeType,
-    params?: ExchangeParams,
-    args?: Record<string, unknown>,
+    options?: ExchangeOptions,
   ): Promise<AMQPExchange<P, C, KP, KC>> {
+    const { arguments: exchangeArguments, ...declarationParams } = options ?? {}
     return this.withOpsChannel(async (ch) => {
-      await ch.exchangeDeclare(name, type, params, args)
+      await ch.exchangeDeclare(name, type, declarationParams, exchangeArguments)
       return new AMQPExchange<P, C, KP, KC>(this, name)
     })
   }
@@ -293,49 +315,33 @@ export class AMQPSession<
    * Declare a direct exchange and return a session-bound {@link AMQPExchange} handle.
    * @param [name="amq.direct"] - exchange name
    */
-  async directExchange(
-    name = "amq.direct",
-    params?: ExchangeParams,
-    args?: Record<string, unknown>,
-  ): Promise<AMQPExchange<P, C, KP, KC>> {
+  async directExchange(name = "amq.direct", options?: ExchangeOptions): Promise<AMQPExchange<P, C, KP, KC>> {
     if (name === "") return new AMQPExchange<P, C, KP, KC>(this, "") // default exchange — no declare needed
-    return this.exchange(name, "direct", params, args)
+    return this.exchange(name, "direct", options)
   }
 
   /**
    * Declare a fanout exchange and return a session-bound {@link AMQPExchange} handle.
    * @param [name="amq.fanout"] - exchange name
    */
-  fanoutExchange(
-    name = "amq.fanout",
-    params?: ExchangeParams,
-    args?: Record<string, unknown>,
-  ): Promise<AMQPExchange<P, C, KP, KC>> {
-    return this.exchange(name, "fanout", params, args)
+  fanoutExchange(name = "amq.fanout", options?: ExchangeOptions): Promise<AMQPExchange<P, C, KP, KC>> {
+    return this.exchange(name, "fanout", options)
   }
 
   /**
    * Declare a topic exchange and return a session-bound {@link AMQPExchange} handle.
    * @param [name="amq.topic"] - exchange name
    */
-  topicExchange(
-    name = "amq.topic",
-    params?: ExchangeParams,
-    args?: Record<string, unknown>,
-  ): Promise<AMQPExchange<P, C, KP, KC>> {
-    return this.exchange(name, "topic", params, args)
+  topicExchange(name = "amq.topic", options?: ExchangeOptions): Promise<AMQPExchange<P, C, KP, KC>> {
+    return this.exchange(name, "topic", options)
   }
 
   /**
    * Declare a headers exchange and return a session-bound {@link AMQPExchange} handle.
    * @param [name="amq.headers"] - exchange name
    */
-  headersExchange(
-    name = "amq.headers",
-    params?: ExchangeParams,
-    args?: Record<string, unknown>,
-  ): Promise<AMQPExchange<P, C, KP, KC>> {
-    return this.exchange(name, "headers", params, args)
+  headersExchange(name = "amq.headers", options?: ExchangeOptions): Promise<AMQPExchange<P, C, KP, KC>> {
+    return this.exchange(name, "headers", options)
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,13 @@ export type { ResolveMessageBody } from "./amqp-publisher.js"
 export { AMQPProperties, Field } from "./amqp-properties.js"
 export { AMQPTlsOptions } from "./amqp-tls-options.js"
 export { AMQPSession } from "./amqp-session.js"
-export type { AMQPSessionOptions } from "./amqp-session.js"
+export type { AMQPSessionOptions, ExchangeOptions, QueueOptions } from "./amqp-session.js"
+export type {
+  AMQPExchangeLike,
+  AMQPQueueLike,
+  AMQPSessionLike,
+  AMQPSubscriptionLike,
+} from "./amqp-mockable.js"
 export { AMQPExchange } from "./amqp-exchange.js"
 export type { ExchangePublishOptions } from "./amqp-exchange.js"
 export { AMQPSubscription, AMQPGeneratorSubscription } from "./amqp-subscription.js"

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -1018,3 +1018,21 @@ test("subscription.cancel() swallows underlying consumer errors", () =>
 
     await expect(sub.cancel()).resolves.toBeUndefined()
   }))
+
+test("queue options: arguments bundle alongside declaration parameters, no positional undefined", () =>
+  withSession(async (session) => {
+    const name = "test-options-bag-" + Math.random()
+    const q = await session.queue(name, {
+      durable: false,
+      autoDelete: true,
+      arguments: { "x-message-ttl": 30_000 },
+    })
+    expect(q.name).toBe(name)
+    // Re-declaring with a mismatched ttl would close the channel —
+    // success here proves the arguments round-tripped on the original declare.
+    await session.queue(name, {
+      durable: false,
+      autoDelete: true,
+      arguments: { "x-message-ttl": 30_000 },
+    })
+  }))

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -1036,3 +1036,12 @@ test("queue options: arguments bundle alongside declaration parameters, no posit
       arguments: { "x-message-ttl": 30_000 },
     })
   }))
+
+test("AMQPSession is structurally assignable to AMQPSessionLike (compile-time)", () => {
+  // Pure type assertion — the import must compile, and the assignment
+  // must satisfy AMQPSessionLike. No runtime broker calls.
+  const checkAssignable = (
+    session: AMQPSession,
+  ): import("../src/amqp-mockable.js").AMQPSessionLike => session
+  expect(typeof checkAssignable).toBe("function")
+})


### PR DESCRIPTION
## Background

Came out of dogfooding the high-level `AMQPSession` API in 84bot (see 84codes/84bot#336). Two ergonomic pain points surfaced; this PR addresses each as a separate commit.

Stacks on top of `message-codec-registry` (PR #192). Server-named queue recovery — a third concern from the dogfooding pass — gets its own follow-up issue (#210).

## Commits

**1. session: fold queue/exchange args into the options bag** — `session.queue(name, params?, args?)` forced callers to pass `undefined` to reach `args`. New shape: `session.queue(name, { durable, autoDelete, args })`. Same for `exchange` / `directExchange` / `fanoutExchange` / `topicExchange` / `headersExchange`. The low-level `AMQPChannel.queueDeclare` signature stays put — it mirrors the AMQP frame layout, which is the right shape there.

**2. session: export `AMQPSessionLike` interfaces for test mocks** — Narrow structural interfaces (`AMQPSessionLike`, `AMQPQueueLike`, `AMQPExchangeLike`, `AMQPSubscriptionLike`) for tests that want to mock the surface without implementing the full class. A compile-time assertion in `test/amqp-session.ts` pins the assignability so the interfaces can't drift.

## Breaking changes

- third positional arg removed from `session.queue` / `session.exchange` / typed-exchange shortcuts (commit 1)

Aligns with the v2 release plan.

## Test plan

- [ ] Existing session test suite keeps passing
- [ ] New tests cover: args via options bag, structural assignability
- [ ] TLS tests skip locally (no TLS broker) — CI to confirm
- [ ] Downstream 84bot consumer updates land separately

## Considered, then dropped

- **`requeueOnNack` default flip** — `amqp-client.rb` defaults `requeue_on_reject: true` and documents the same semantics. The "requeue is safe, drop is opt-in" convention is established across both libs. Callers that want drop-on-error pass `requeueOnNack: false` explicitly.
- **Default parsers to `builtinParsers`** — `amqp-client.rb`'s `MessageCodecRegistry` starts empty and requires an explicit `enable_builtin_parsers` call. Keeping JS aligned: users opt in by passing `parsers: builtinParsers`.

## Not in this PR

- **Server-named/anonymous queue recovery** — tracked in #210.