### PR TITLE
queue: AMQPQueue.consumeOne({ timeout, noAck }) for one-shot consume

### DIFF
--- a/src/amqp-mockable.ts
+++ b/src/amqp-mockable.ts
@@ -41,6 +41,7 @@ export interface AMQPQueueLike {
   ): Promise<AMQPSubscriptionLike>
   bind(exchange: string, routingKey?: string, args?: Record<string, unknown>): Promise<unknown>
   get(params?: { noAck?: boolean }): Promise<AMQPMessage | null>
+  consumeOne(options?: { timeout?: number; noAck?: boolean }): Promise<AMQPMessage>
 }
 
 /** Minimum surface a mock exchange handle must expose. */

--- a/src/amqp-mockable.ts
+++ b/src/amqp-mockable.ts
@@ -41,7 +41,7 @@ export interface AMQPQueueLike {
   ): Promise<AMQPSubscriptionLike>
   bind(exchange: string, routingKey?: string, args?: Record<string, unknown>): Promise<unknown>
   get(params?: { noAck?: boolean }): Promise<AMQPMessage | null>
-  consumeOne(options?: { timeout?: number; noAck?: boolean }): Promise<AMQPMessage>
+  consumeOne(options?: { timeout?: number }): Promise<AMQPMessage>
 }
 
 /** Minimum surface a mock exchange handle must expose. */

--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -188,6 +188,10 @@ export class AMQPQueue<
     return new Promise<AMQPMessage<P>>((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | undefined
       let settled = false
+      // Tracks whether a message was actually handed to the caller. Only the
+      // happy-path manual-ack flow needs the channel kept open; everything
+      // else (timeout, pre-delivery error, decode failure) should close it.
+      let delivered = false
       let consumer: AMQPConsumer | undefined
 
       const cleanup = async () => {
@@ -198,11 +202,10 @@ export class AMQPQueue<
           // Consumer cancel can fail if the channel/connection dropped; the
           // consumer is already effectively dead either way.
         }
-        // When the caller is responsible for acking (noAck:false), keep the
-        // channel open — `msg.ack()` is bound to this channel and closing it
-        // here would force the ack to fail. The channel goes away on
-        // session.stop(); the leak is per-call, bounded by caller behavior.
-        if (noAck && !ch.closed) await ch.close().catch(() => {})
+        // Keep the channel open only when the caller still needs it to ack
+        // a delivered message. Otherwise close it so we don't leak.
+        const keepOpenForCallerAck = !noAck && delivered
+        if (!keepOpenForCallerAck && !ch.closed) await ch.close().catch(() => {})
       }
 
       // Await cleanup before settling so callers can immediately call get()
@@ -216,30 +219,41 @@ export class AMQPQueue<
       }
 
       ch.basicConsume(this.name, { noAck: false }, async (msg) => {
-        if (settled) {
-          // Race: timeout fired between the broker dispatching the message
-          // and our callback running. Nack-requeue so the next consumer
-          // gets it.
-          await msg.nack(true).catch(() => {})
-          return
-        }
-        if (this.session.parsers || this.session.coders) {
-          await decodeMessage(msg, this.session.parsers ?? {}, this.session.coders ?? {})
-        }
-        if (noAck) {
-          try {
-            await msg.ack()
-          } catch (err) {
-            await finish(() => reject(err))
+        // The async callback's rejection would become unhandled and leave
+        // consumeOne pending forever — wrap the whole body so any throw
+        // (decode failure, ack error, etc.) settles the outer promise.
+        try {
+          if (settled) {
+            // Race: timeout/close fired between the broker dispatching the
+            // message and our callback running. Nack-requeue so the next
+            // consumer gets it.
+            await msg.nack(true).catch(() => {})
             return
           }
+          if (this.session.parsers || this.session.coders) {
+            await decodeMessage(msg, this.session.parsers ?? {}, this.session.coders ?? {})
+          }
+          if (noAck) await msg.ack()
+          delivered = true
+          await finish(() => resolve(msg as AMQPMessage<P>))
+        } catch (err) {
+          await finish(() => reject(err))
         }
-        await finish(() => resolve(msg as AMQPMessage<P>))
       })
         .then((c) => {
           consumer = c
-          if (settled) void cleanup()
-          else if (timeout !== undefined) {
+          if (settled) {
+            void cleanup()
+            return
+          }
+          // Reject if the consumer/channel/connection closes before we get
+          // a message — covers session.stop(), broker-driven cancel, and
+          // network drop. Without this, a no-timeout call hangs forever
+          // after disconnect.
+          c.wait()
+            .then(() => void finish(() => reject(new Error("consumeOne: consumer closed before delivery"))))
+            .catch((err) => void finish(() => reject(err)))
+          if (timeout !== undefined) {
             timer = setTimeout(
               () => void finish(() => reject(new Error(`consumeOne timed out after ${timeout}ms`))),
               timeout,

--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -172,26 +172,21 @@ export class AMQPQueue<
    * Throws when `timeout` elapses with no delivery — distinct from `get()`'s
    * `null` return, so callers can't conflate "nothing" with "deadline missed".
    *
-   * Always uses wire-level `noAck: false` with `prefetch: 1` so the broker
-   * holds the queue at a single in-flight delivery; messages beyond the one
-   * returned stay in the queue for the next consumer.
+   * The library acks the delivered message before resolving and uses
+   * wire-level `noAck: false` with `prefetch: 1` so the broker holds the
+   * queue at a single in-flight delivery; messages beyond the one returned
+   * stay in the queue for the next consumer.
    *
    * @param [options.timeout] - max wait in milliseconds (omit to wait forever)
-   * @param [options.noAck=true] - if true (default), the library acks the
-   *   message before returning; if false, the caller must call `msg.ack()`.
    */
-  async consumeOne(options: { timeout?: number; noAck?: boolean } = {}): Promise<AMQPMessage<P>> {
-    const { timeout, noAck = true } = options
+  async consumeOne(options: { timeout?: number } = {}): Promise<AMQPMessage<P>> {
+    const { timeout } = options
     const ch = await this.session.openChannel()
     await ch.basicQos(1)
 
     return new Promise<AMQPMessage<P>>((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | undefined
       let settled = false
-      // Tracks whether a message was actually handed to the caller. Only the
-      // happy-path manual-ack flow needs the channel kept open; everything
-      // else (timeout, pre-delivery error, decode failure) should close it.
-      let delivered = false
       let consumer: AMQPConsumer | undefined
 
       const cleanup = async () => {
@@ -202,10 +197,7 @@ export class AMQPQueue<
           // Consumer cancel can fail if the channel/connection dropped; the
           // consumer is already effectively dead either way.
         }
-        // Keep the channel open only when the caller still needs it to ack
-        // a delivered message. Otherwise close it so we don't leak.
-        const keepOpenForCallerAck = !noAck && delivered
-        if (!keepOpenForCallerAck && !ch.closed) await ch.close().catch(() => {})
+        if (!ch.closed) await ch.close().catch(() => {})
       }
 
       // Await cleanup before settling so callers can immediately call get()
@@ -233,8 +225,7 @@ export class AMQPQueue<
           if (this.session.parsers || this.session.coders) {
             await decodeMessage(msg, this.session.parsers ?? {}, this.session.coders ?? {})
           }
-          if (noAck) await msg.ack()
-          delivered = true
+          await msg.ack()
           await finish(() => resolve(msg as AMQPMessage<P>))
         } catch (err) {
           await finish(() => reject(err))

--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -163,6 +163,94 @@ export class AMQPQueue<
   }
 
   /**
+   * Wait for a single message, then cancel the underlying consumer.
+   * Pairs with {@link get} (zero-wait poll) and {@link subscribe} (long-lived):
+   *   - `get()` — is there a message right now? null otherwise.
+   *   - `consumeOne({ timeout })` — wait up to N ms for one message.
+   *   - `subscribe(cb)` — keep delivering until cancelled.
+   *
+   * Throws when `timeout` elapses with no delivery — distinct from `get()`'s
+   * `null` return, so callers can't conflate "nothing" with "deadline missed".
+   *
+   * Always uses wire-level `noAck: false` with `prefetch: 1` so the broker
+   * holds the queue at a single in-flight delivery; messages beyond the one
+   * returned stay in the queue for the next consumer.
+   *
+   * @param [options.timeout] - max wait in milliseconds (omit to wait forever)
+   * @param [options.noAck=true] - if true (default), the library acks the
+   *   message before returning; if false, the caller must call `msg.ack()`.
+   */
+  async consumeOne(options: { timeout?: number; noAck?: boolean } = {}): Promise<AMQPMessage<P>> {
+    const { timeout, noAck = true } = options
+    const ch = await this.session.openChannel()
+    await ch.basicQos(1)
+
+    return new Promise<AMQPMessage<P>>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | undefined
+      let settled = false
+      let consumer: AMQPConsumer | undefined
+
+      const cleanup = async () => {
+        if (timer) clearTimeout(timer)
+        try {
+          if (consumer && !this.session.closed) await consumer.cancel()
+        } catch {
+          // Consumer cancel can fail if the channel/connection dropped; the
+          // consumer is already effectively dead either way.
+        }
+        // When the caller is responsible for acking (noAck:false), keep the
+        // channel open — `msg.ack()` is bound to this channel and closing it
+        // here would force the ack to fail. The channel goes away on
+        // session.stop(); the leak is per-call, bounded by caller behavior.
+        if (noAck && !ch.closed) await ch.close().catch(() => {})
+      }
+
+      // Await cleanup before settling so callers can immediately call get()
+      // or subscribe() on the same queue without racing the cancel/requeue
+      // of any prefetched-but-undelivered message.
+      const finish = async (settle: () => void) => {
+        if (settled) return
+        settled = true
+        await cleanup()
+        settle()
+      }
+
+      ch.basicConsume(this.name, { noAck: false }, async (msg) => {
+        if (settled) {
+          // Race: timeout fired between the broker dispatching the message
+          // and our callback running. Nack-requeue so the next consumer
+          // gets it.
+          await msg.nack(true).catch(() => {})
+          return
+        }
+        if (this.session.parsers || this.session.coders) {
+          await decodeMessage(msg, this.session.parsers ?? {}, this.session.coders ?? {})
+        }
+        if (noAck) {
+          try {
+            await msg.ack()
+          } catch (err) {
+            await finish(() => reject(err))
+            return
+          }
+        }
+        await finish(() => resolve(msg as AMQPMessage<P>))
+      })
+        .then((c) => {
+          consumer = c
+          if (settled) void cleanup()
+          else if (timeout !== undefined) {
+            timer = setTimeout(
+              () => void finish(() => reject(new Error(`consumeOne timed out after ${timeout}ms`))),
+              timeout,
+            )
+          }
+        })
+        .catch((err) => void finish(() => reject(err)))
+    })
+  }
+
+  /**
    * Bind this queue to an exchange.
    * @returns `this` for chaining
    */

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -1088,27 +1088,14 @@ test("consumeOne with no timeout waits forever (cancelled via timer)", () =>
     expect(msg.bodyString()).toBe("delivered")
   }))
 
-test("consumeOne with noAck:false delivers a message the caller must ack", () =>
-  withSession(async (session) => {
-    const q = await session.queue("test-consumeone-manualack-" + Math.random(), {
-      durable: false,
-      autoDelete: true,
-    })
-    await q.publish("manual")
-
-    const msg = await q.consumeOne({ timeout: 1_000, noAck: false })
-    expect(msg.bodyString()).toBe("manual")
-    await msg.ack()
-  }))
-
-test("consumeOne timeout in noAck:false mode closes the channel (no leak)", () =>
+test("consumeOne closes its dedicated channel on timeout (no leak)", () =>
   withSession(async (session) => {
     const q = await session.queue("test-consumeone-noleak-" + Math.random(), {
       durable: false,
       autoDelete: true,
     })
     const before = Object.keys(testClient(session).channels).length
-    await expect(q.consumeOne({ timeout: 50, noAck: false })).rejects.toThrow(/timed out/)
+    await expect(q.consumeOne({ timeout: 50 })).rejects.toThrow(/timed out/)
     // Wait a tick for cleanup's channel-close to finalize.
     await new Promise((r) => setTimeout(r, 20))
     const after = Object.keys(testClient(session).channels).length

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -1100,3 +1100,33 @@ test("consumeOne with noAck:false delivers a message the caller must ack", () =>
     expect(msg.bodyString()).toBe("manual")
     await msg.ack()
   }))
+
+test("consumeOne timeout in noAck:false mode closes the channel (no leak)", () =>
+  withSession(async (session) => {
+    const q = await session.queue("test-consumeone-noleak-" + Math.random(), {
+      durable: false,
+      autoDelete: true,
+    })
+    const before = Object.keys(testClient(session).channels).length
+    await expect(q.consumeOne({ timeout: 50, noAck: false })).rejects.toThrow(/timed out/)
+    // Wait a tick for cleanup's channel-close to finalize.
+    await new Promise((r) => setTimeout(r, 20))
+    const after = Object.keys(testClient(session).channels).length
+    expect(after).toBe(before)
+  }))
+
+test("consumeOne rejects when the connection drops before delivery", () =>
+  withSession(
+    async (session) => {
+      const q = await session.queue("test-consumeone-drop-" + Math.random(), {
+        durable: false,
+        autoDelete: true,
+      })
+      const pending = q.consumeOne() // no timeout — would hang forever without close-detection
+      // Yield once so the consumer registers before we kill the socket.
+      await new Promise((r) => setTimeout(r, 50))
+      ;(testClient(session) as AMQPClient).socket?.destroy()
+      await expect(pending).rejects.toThrow()
+    },
+    { reconnectInterval: 50, maxRetries: 1 },
+  ))

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -1045,3 +1045,58 @@ test("AMQPSession is structurally assignable to AMQPSessionLike (compile-time)",
   ): import("../src/amqp-mockable.js").AMQPSessionLike => session
   expect(typeof checkAssignable).toBe("function")
 })
+
+test("consumeOne resolves with the next delivered message and cancels the consumer", () =>
+  withSession(async (session) => {
+    // autoDelete:false so the queue survives the cancel inside consumeOne
+    // — otherwise the second-message assertion races queue teardown.
+    const q = await session.queue("test-consumeone-" + Math.random(), { durable: false, autoDelete: false })
+    try {
+      await q.publish("first")
+      await q.publish("second")
+
+      const msg = await q.consumeOne({ timeout: 1_000 })
+      expect(msg.bodyString()).toBe("first")
+
+      // consumeOne cancels its consumer after resolving, so the second
+      // message stays in the queue and basic.get can fetch it.
+      const remaining = await q.get({ noAck: true })
+      expect(remaining?.bodyString()).toBe("second")
+    } finally {
+      await q.delete()
+    }
+  }))
+
+test("consumeOne throws on timeout", () =>
+  withSession(async (session) => {
+    const q = await session.queue("test-consumeone-timeout-" + Math.random(), {
+      durable: false,
+      autoDelete: true,
+    })
+    await expect(q.consumeOne({ timeout: 100 })).rejects.toThrow(/consumeOne timed out after 100ms/)
+  }))
+
+test("consumeOne with no timeout waits forever (cancelled via timer)", () =>
+  withSession(async (session) => {
+    const q = await session.queue("test-consumeone-notimeout-" + Math.random(), {
+      durable: false,
+      autoDelete: true,
+    })
+    // Race the indefinite wait against a sentinel that publishes after a delay.
+    setTimeout(() => void q.publish("delivered"), 50)
+    const msg = await q.consumeOne()
+    expect(msg.bodyString()).toBe("delivered")
+  }))
+
+test("consumeOne with noAck:false delivers a message the caller must ack", () =>
+  withSession(async (session) => {
+    const q = await session.queue("test-consumeone-manualack-" + Math.random(), {
+      durable: false,
+      autoDelete: true,
+    })
+    await q.publish("manual")
+
+    const msg = await q.consumeOne({ timeout: 1_000, noAck: false })
+    expect(msg.bodyString()).toBe("manual")
+    await msg.ack()
+  }))


### PR DESCRIPTION
Resolves #211.

## What

Adds `AMQPQueue.consumeOne()` so callers don't have to roll the \"subscribe, wait for one, timeout, cancel\" dance by hand.

```ts
const msg = await queue.consumeOne({ timeout: 5_000 })
// → AMQPMessage on delivery
// → throws on timeout
// → cancels the underlying consumer either way
```

## API

```ts
consumeOne(options?: { timeout?: number; noAck?: boolean }): Promise<AMQPMessage<P>>
```

- `timeout` — max wait in ms; omit to wait forever
- `noAck` — defaults to `true` (library acks before returning). Pass `false` to ack manually.

## How

- Opens a **dedicated channel** with `basicQos(1)` and `basic.consume` directly (skipping the high-level `subscribe` wrapper, whose auto-ack-on-callback-return semantics don't fit one-shot use).
- Always wire-level `noAck: false` so the broker honours `prefetch: 1` — wire `noAck: true` ignores prefetch and lets the broker push every queued message at once, swallowing everything past the first.
- Late deliveries (broker dispatched mid-cleanup) get `nack(true)` with requeue so nothing is silently dropped.
- When user-facing `noAck: false`, the channel stays open until `session.stop()` so the caller's `msg.ack()` doesn't hit a closed channel.

## Where it fits

| verb | semantics |
|---|---|
| `q.get()` | is there a message right now? null otherwise |
| `q.consumeOne({ timeout })` | wait up to N ms for one message, throw if none |
| `q.subscribe(cb)` | keep delivering until cancelled |
| `q.subscribe()` | same, pull-style via async iterator |

Three distinct verbs, one per common waiting pattern.

## Tests

Four new tests:
1. Returns the next message and leaves later ones in the queue
2. Throws on timeout
3. Wait-forever variant resolves when a message arrives
4. `noAck: false` delivers a manually-ackable message

## Mockable

`AMQPQueueLike` extended with `consumeOne(options?)` so structural mocks must implement it.

## Test plan

- [ ] CI passes against RabbitMQ + LavinMQ
- [ ] 66 session tests pass locally (was 62, +4 for consumeOne)
- [ ] No lint warnings