### PR TITLE
subscription: cancel() closes the dedicated channel it owns

### DIFF
--- a/src/amqp-subscription.ts
+++ b/src/amqp-subscription.ts
@@ -49,7 +49,13 @@ export class AMQPSubscription {
   }
 
   /**
-   * Cancel the subscription and remove it from session auto-recovery.
+   * Cancel the subscription, close its dedicated channel, and remove it
+   * from session auto-recovery.
+   *
+   * The subscription owns the channel that `queue.subscribe()` opened
+   * for it, so cancelling here also closes that channel — otherwise
+   * each cancelled subscription leaks a channel until the connection
+   * drops.
    *
    * Best-effort: never throws on wire-level failures. If the channel
    * dropped mid-cancel or the broker is gone, the consumer is already
@@ -59,11 +65,19 @@ export class AMQPSubscription {
    */
   async cancel(): Promise<void> {
     this.onCancel?.()
+    const ch = this.consumer.channel
     try {
       await this.consumer.cancel()
     } catch {
       // Channel/connection closed before basic.cancel could complete —
       // the consumer is gone either way.
+    }
+    if (!ch.closed) {
+      try {
+        await ch.close()
+      } catch {
+        // Channel/connection dropped before close could complete.
+      }
     }
   }
 

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -77,6 +77,37 @@ test("subscription.cancel() removes it from session recovery", () =>
     await expect(sub.cancel()).resolves.toBeUndefined()
   }))
 
+test("subscription.cancel() closes the dedicated channel", () =>
+  withSession(async (session) => {
+    const q = await session.queue("test-cancel-channel-" + Math.random(), { durable: false, autoDelete: true })
+    const sub = await q.subscribe({ noAck: true }, () => {})
+    const ch = sub.channel
+
+    expect(ch.closed).toBe(false)
+    await sub.cancel()
+    expect(ch.closed).toBe(true)
+  }))
+
+test("repeated subscribe/cancel does not leak channels", () =>
+  withSession(async (session) => {
+    // autoDelete: false so the queue survives between subscribe/cancel cycles.
+    const q = await session.queue("test-cancel-leak-" + Math.random(), { durable: false, autoDelete: false })
+    try {
+      const client = testClient(session)
+      const openCount = () => client.channels.filter(Boolean).length
+      const before = openCount()
+
+      for (let i = 0; i < 5; i++) {
+        const sub = await q.subscribe({ noAck: true }, () => {})
+        await sub.cancel()
+      }
+
+      expect(openCount()).toBe(before)
+    } finally {
+      await q.delete()
+    }
+  }))
+
 test("session.subscribe supports prefetch option", () =>
   withSession(async (session) => {
     const q = await session.queue("test-prefetch-queue-" + Math.random(), { durable: false, autoDelete: true })


### PR DESCRIPTION
## Background

Subscribers were leaking AMQP channels because `sub.cancel()` only sent `basic.cancel` and left the dedicated channel open. Workaround there was an explicit `ch.close()` after each `sub.cancel()`. The fix belongs here, in the high-level API.

`queue.subscribe()` opens a dedicated channel per subscription (`openConsumer` at `src/amqp-queue.ts:329`). The subscription owns that channel — cancelling the subscription should also close it. Until the connection drops, every cancelled subscription was leaving a channel hanging around.

## Summary

- `AMQPSubscription.cancel()` now closes the channel after cancelling the consumer
- Guarded by `ch.closed` and wrapped in `try/catch` to keep the best-effort, never-throws contract
- Same pattern `consumeOne()` already uses

## Test plan

- [x] `npx vitest run test/amqp-session.ts` — all 69 pass
- [x] `npm run format:check && npm run lint && npm run typecheck` — clean
- [x] New regression test: `subscription.cancel() closes the dedicated channel`
- [x] New regression test: `repeated subscribe/cancel does not leak channels`