### PR TITLE
session: move on{connect,disconnect,failed} into the options bag

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ const session = await AMQPSession.connect("amqp://localhost", {
   maxReconnectInterval: 30000, // maximum delay between attempts (ms)
   backoffMultiplier: 2, // exponential backoff multiplier
   maxRetries: 0, // 0 = infinite retries
+  onconnect: () => console.log("Connected"), // fires on initial connect + each reconnect
+  ondisconnect: (err) => console.warn("Disconnected:", err?.message),
+  onfailed: (err) => console.error("Gave up:", err?.message),
 })
-
-session.onconnect = () => console.log("Reconnected!")
-session.onfailed = (err) => console.error("Gave up:", err?.message)
 ```
 
 #### Consumer recovery

--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -70,6 +70,20 @@ export interface AMQPSessionOptions<
    * Defaults to `"/"` for WebSocket connections and to the URL path for TCP connections.
    */
   vhost?: string
+  /**
+   * Fires after a successful connection — both the initial connect and every
+   * reconnect after consumer recovery completes. Registering here rather than
+   * after `connect()` resolves means a single handler covers both code paths.
+   */
+  onconnect?: () => void
+  /**
+   * Fires when the underlying connection drops, before the reconnect loop
+   * starts. Useful for visibility into the gap between disconnect and
+   * reconnect.
+   */
+  ondisconnect?: (error?: Error) => void
+  /** Fires when max reconnect retries are exhausted. */
+  onfailed?: (error?: Error) => void
 }
 
 /**
@@ -88,10 +102,9 @@ export class AMQPSession<
   KP extends keyof P & string = never,
   KC extends keyof C & string = never,
 > {
-  /** Fires after a successful (re)connection and consumer recovery */
-  onconnect?: () => void
-  /** Fires when max retries are exhausted */
-  onfailed?: (error?: Error) => void
+  private readonly onconnect?: () => void
+  private readonly ondisconnect?: (error?: Error) => void
+  private readonly onfailed?: (error?: Error) => void
 
   private readonly client: AMQPBaseClient
 
@@ -142,17 +155,21 @@ export class AMQPSession<
     if (options?.coders) this.coders = options.coders
     if (options?.defaultContentType) this.defaultContentType = options.defaultContentType
     if (options?.defaultContentEncoding) this.defaultContentEncoding = options.defaultContentEncoding
+    if (options?.onconnect) this.onconnect = options.onconnect
+    if (options?.ondisconnect) this.ondisconnect = options.ondisconnect
+    if (options?.onfailed) this.onfailed = options.onfailed
     this.options = {
       reconnectInterval: options?.reconnectInterval ?? 1000,
       maxReconnectInterval: options?.maxReconnectInterval ?? 30000,
       backoffMultiplier: options?.backoffMultiplier ?? 2,
       maxRetries: options?.maxRetries ?? 0,
     }
-    this.client.ondisconnect = () => {
+    this.client.ondisconnect = (err) => {
       this.opsChannel = null
       this.confirmChannel = null
       this.opsChannelPromise = null
       this.confirmChannelPromise = null
+      this.ondisconnect?.(err)
       if (!this.stopped && !this.reconnecting) {
         void this.reconnectLoop()
       }
@@ -196,7 +213,9 @@ export class AMQPSession<
       client = new AMQPClient(url, options?.tlsOptions, options?.logger)
     }
     await client.connect()
-    return new AMQPSession(client, options)
+    const session = new AMQPSession(client, options)
+    options?.onconnect?.()
+    return session
   }
 
   /**

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -147,52 +147,88 @@ test("session.subscribe yields messages via async generator", () =>
     await sub.cancel()
   }))
 
-test("session.onfailed fires when maxRetries exhausted", () =>
-  withSession(
-    async (session) => {
-      const onfailed = vi.fn()
-      session.onfailed = onfailed
+test("onfailed fires when maxRetries exhausted", async () => {
+  const onfailed = vi.fn()
+  const session = await AMQPSession.connect("amqp://127.0.0.1", {
+    reconnectInterval: 50,
+    maxRetries: 2,
+    onfailed,
+  })
+  try {
+    const client = testClient(session)
+    const connectSpy = vi.spyOn(client, "connect").mockRejectedValue(new Error("forced failure"))
 
-      const client = testClient(session)
-      const connectSpy = vi.spyOn(client, "connect").mockRejectedValue(new Error("forced failure"))
+    ;(client as AMQPClient).socket?.destroy()
 
-      ;(client as AMQPClient).socket?.destroy()
+    // Wait long enough for 2 retries + backoff (50ms + 100ms) with buffer
+    await new Promise((resolve) => setTimeout(resolve, 500))
 
-      // Wait long enough for 2 retries + backoff (50ms + 100ms) with buffer
-      await new Promise((resolve) => setTimeout(resolve, 500))
+    expect(onfailed).toHaveBeenCalledTimes(1)
+    expect(onfailed.mock.calls[0]?.[0]).toBeInstanceOf(Error)
+    expect(connectSpy).toHaveBeenCalledTimes(2)
 
-      expect(onfailed).toHaveBeenCalledTimes(1)
-      expect(onfailed.mock.calls[0]?.[0]).toBeInstanceOf(Error)
-      expect(connectSpy).toHaveBeenCalledTimes(2)
+    connectSpy.mockRestore()
+  } finally {
+    await session.stop()
+  }
+})
 
-      connectSpy.mockRestore()
-    },
-    { reconnectInterval: 50, maxRetries: 2 },
-  ))
+test("onconnect fires on the initial connect", async () => {
+  const onconnect = vi.fn()
+  const session = await AMQPSession.connect("amqp://127.0.0.1", { onconnect })
+  try {
+    expect(onconnect).toHaveBeenCalledTimes(1)
+  } finally {
+    await session.stop()
+  }
+})
 
-test("session.onconnect fires after successful reconnection", () =>
-  withSession(
-    async (session) => {
-      let reconnectCount = 0
-      const reconnected = new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => reject(new Error("onconnect did not fire within 5s")), 5_000)
-        session.onconnect = () => {
+test("onconnect fires after successful reconnection", async () => {
+  let count = 0
+  const reconnected = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("onconnect did not fire within 5s")), 5_000)
+    const session = AMQPSession.connect("amqp://127.0.0.1", {
+      reconnectInterval: 50,
+      maxRetries: 5,
+      onconnect: () => {
+        count++
+        if (count === 2) {
           clearTimeout(timeout)
-          reconnectCount++
           resolve()
         }
-      })
+      },
+    })
+    session.then((s) => (testClient(s) as AMQPClient).socket?.destroy()).catch(reject)
+  })
+  await reconnected
+  expect(count).toBe(2)
+})
 
-      ;(testClient(session) as AMQPClient).socket?.destroy()
+test("ondisconnect fires when the connection drops", async () => {
+  const ondisconnect = vi.fn()
+  const session = await AMQPSession.connect("amqp://127.0.0.1", {
+    reconnectInterval: 50,
+    maxRetries: 5,
+    ondisconnect,
+  })
+  try {
+    ;(testClient(session) as AMQPClient).socket?.destroy()
+    // Give the disconnect callback time to fire before the reconnect kicks in.
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(ondisconnect).toHaveBeenCalledTimes(1)
+  } finally {
+    await session.stop()
+  }
+})
 
-      await reconnected
-      expect(reconnectCount).toBe(1)
-    },
-    { reconnectInterval: 50, maxRetries: 5 },
-  ))
-
-test("subscription recovers and receives messages after reconnection", () =>
-  withSession(
+test("subscription recovers and receives messages after reconnection", async () => {
+  let connectCount = 0
+  let resolveReconnected!: () => void
+  const reconnected = new Promise<void>((resolve, reject) => {
+    resolveReconnected = resolve
+    setTimeout(() => reject(new Error("Reconnection timed out")), 10_000)
+  })
+  await withSession(
     async (session) => {
       const q = await session.queue("test-recovery-" + Math.random(), { durable: false, autoDelete: false })
 
@@ -204,15 +240,6 @@ test("subscription recovers and receives messages after reconnection", () =>
       // Publish a message before disconnect
       await q.publish("before-disconnect", { confirm: false })
       await new Promise((resolve) => setTimeout(resolve, 100))
-
-      const reconnected = new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => reject(new Error("Reconnection timed out")), 10_000)
-        session.onconnect = () => {
-          clearTimeout(timeout)
-          resolve()
-        }
-      })
-
       ;(testClient(session) as AMQPClient).socket?.destroy()
 
       await reconnected
@@ -230,8 +257,16 @@ test("subscription recovers and receives messages after reconnection", () =>
       await sub.cancel()
       await q.delete()
     },
-    { reconnectInterval: 50, maxRetries: 5 },
-  ))
+    {
+      reconnectInterval: 50,
+      maxRetries: 5,
+      onconnect: () => {
+        connectCount++
+        if (connectCount === 2) resolveReconnected()
+      },
+    },
+  )
+})
 
 test("session.stop() during reconnection stops the loop", () =>
   withSession(
@@ -330,8 +365,14 @@ test("AMQPExchange.publish() honors explicit deliveryMode: 1 (transient)", () =>
     expect(msg?.properties.deliveryMode).toBe(1)
   }))
 
-test("AMQPQueue (session-backed).subscribe() recovers after reconnect", () =>
-  withSession(
+test("AMQPQueue (session-backed).subscribe() recovers after reconnect", async () => {
+  let connectCount = 0
+  let resolveReconnected!: () => void
+  const reconnected = new Promise<void>((resolve, reject) => {
+    resolveReconnected = resolve
+    setTimeout(() => reject(new Error("reconnect timed out")), 10_000)
+  })
+  await withSession(
     async (session) => {
       const qName = "test-sq-recovery-" + Math.random()
 
@@ -344,14 +385,6 @@ test("AMQPQueue (session-backed).subscribe() recovers after reconnect", () =>
 
       await q.publish("before-disconnect")
       await new Promise((resolve) => setTimeout(resolve, 100))
-
-      const reconnected = new Promise<void>((resolve, reject) => {
-        const t = setTimeout(() => reject(new Error("reconnect timed out")), 10_000)
-        session.onconnect = () => {
-          clearTimeout(t)
-          resolve()
-        }
-      })
       ;(testClient(session) as AMQPClient).socket?.destroy()
       await reconnected
 
@@ -364,8 +397,16 @@ test("AMQPQueue (session-backed).subscribe() recovers after reconnect", () =>
       await sub.cancel()
       await q.delete()
     },
-    { reconnectInterval: 50, maxRetries: 5 },
-  ))
+    {
+      reconnectInterval: 50,
+      maxRetries: 5,
+      onconnect: () => {
+        connectCount++
+        if (connectCount === 2) resolveReconnected()
+      },
+    },
+  )
+})
 
 test("session.exchange() declares an exchange and returns AMQPExchange", () =>
   withSession(async (session) => {


### PR DESCRIPTION
Closes #215.

## Background

`AMQPSession.onconnect` and `onfailed` were assignable properties on the session, so they could only be set *after* `AMQPSession.connect()` resolved. By then the initial connect had already happened — the callback never fired for it, only for subsequent reconnects. Callers ended up writing the "connected" handler twice:

```js
const session = await AMQPSession.connect(url)
session.onconnect = () => console.log("connected (reconnect)")
console.log("connected (initial)")
```

Asymmetric, surprising, and a needless rough edge.

## Summary

- `onconnect`, `ondisconnect`, `onfailed` now live in the `AMQPSessionOptions` bag passed to `AMQPSession.connect()`
- `onconnect` fires for the initial connect and every reconnect — single code path
- `ondisconnect` is new: fires when the connection drops, before the reconnect loop starts (useful for visibility into the gap)
- The public property setters are removed

```js
const session = await AMQPSession.connect(url, {
  onconnect: () => console.log("connected"),
  ondisconnect: (err) => console.warn("disconnected:", err?.message),
  onfailed: (err) => console.error("gave up:", err?.message),
})
```

## Test plan

- [x] `npx vitest run test/amqp-session.ts` — all 69 pass
- [x] `npm run format:check && npm run lint && npm run typecheck` — clean
- [x] New test: `onconnect fires on the initial connect`
- [x] New test: `ondisconnect fires when the connection drops`
- [x] Existing reconnect/recovery tests refactored to use the options bag (counter that fires on the 2nd `onconnect`)