### PR TITLE
Remove `ch.close()` as it is handled by `sub.cancel()`

### DIFF
--- a/src/amqp-rpc-server.ts
+++ b/src/amqp-rpc-server.ts
@@ -79,8 +79,6 @@ export class AMQPRPCServer<
     const sub = this.subscription
     if (!sub) return
     this.subscription = null
-    const ch = sub.channel
     await sub.cancel()
-    if (!ch.closed) await ch.close()
   }
 }


### PR DESCRIPTION
`sub.cancel()` closes its dedicated channel since https://github.com/cloudamqp/amqp-client.js/commit/de0e8dc, no need of handling channels here.