### PR TITLE
Identity encoding no-op

### DIFF
--- a/src/amqp-codec-registry.ts
+++ b/src/amqp-codec-registry.ts
@@ -152,7 +152,7 @@ export function serializeAndEncode(
     )
   }
 
-  if (props.contentEncoding) {
+  if (props.contentEncoding && props.contentEncoding.toLowerCase() !== "identity") {
     const coder = coders[props.contentEncoding]
     if (!coder) {
       throw new Error(`No coder registered for content-encoding "${props.contentEncoding}".`)
@@ -169,7 +169,7 @@ export function decodeAndParse(
   body: Uint8Array,
   properties: AMQPProperties,
 ): Promise<unknown> | unknown {
-  if (properties.contentEncoding) {
+  if (properties.contentEncoding && properties.contentEncoding.toLowerCase() !== "identity") {
     const coder = coders[properties.contentEncoding]
     if (!coder) {
       throw new Error(`No coder registered for content-encoding "${properties.contentEncoding}".`)

--- a/test/amqp-codec-registry.ts
+++ b/test/amqp-codec-registry.ts
@@ -166,6 +166,27 @@ describe("builtin parsers and coders", () => {
       ).toThrow(/No coder registered/)
     })
 
+    test("contentEncoding 'identity' is a no-op even with no coders", async () => {
+      const { body, properties } = await serializeAndEncode(builtinParsers, noCoders, "hello", {
+        contentType: "text/plain",
+        contentEncoding: "identity",
+      })
+      expect(properties.contentEncoding).toBe("identity")
+      expect(new TextDecoder().decode(body)).toBe("hello")
+
+      const parsed = await decodeAndParse(builtinParsers, noCoders, body, properties)
+      expect(parsed).toBe("hello")
+    })
+
+    test("contentEncoding 'identity' is case-insensitive", async () => {
+      const { body, properties } = await serializeAndEncode(builtinParsers, noCoders, "hi", {
+        contentType: "text/plain",
+        contentEncoding: "Identity",
+      })
+      const parsed = await decodeAndParse(builtinParsers, noCoders, body, properties)
+      expect(parsed).toBe("hi")
+    })
+
     test("throws for non-bytes body without contentType", () => {
       expect(() => serializeAndEncode(noParsers, noCoders, { foo: "bar" }, {})).toThrow(/no contentType specified/)
     })


### PR DESCRIPTION
Publishing `q.publish("x", { contentEncoding: "identity" })` throws even though "identity" per [RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616#section-3.5) means no encoding applied. User wanting to set metadata only on a session with no coders configured cannot.

This PR enforces "identity" as a "no-op" for contentEncoding. 