### PR TITLE
Session: cache queue handle on bare queue(name) re-call

### DIFF
--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -297,11 +297,14 @@ export class AMQPSession<
    * Declare a queue and return a session-bound {@link AMQPQueue} handle.
    * The returned queue's `subscribe` uses auto-recovery and `publish` waits for
    * a broker confirm.
+   *
+   * Subsequent calls with the same name return the cached handle without
+   * redeclaring, and `options` on those calls are ignored.
    * @param name - queue name (use "" to let the broker generate a name)
    * @param [options] - queue declaration parameters and queue arguments
    */
   async queue(name: string, options?: QueueOptions): Promise<AMQPQueue<P, C, KP, KC>> {
-    if (options === undefined && name !== "") {
+    if (name !== "") {
       const cached = this.queues.get(name)
       if (cached) return cached
     }

--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -301,6 +301,10 @@ export class AMQPSession<
    * @param [options] - queue declaration parameters and queue arguments
    */
   async queue(name: string, options?: QueueOptions): Promise<AMQPQueue<P, C, KP, KC>> {
+    if (options === undefined && name !== "") {
+      const cached = this.queues.get(name)
+      if (cached) return cached
+    }
     const { arguments: queueArguments, ...declarationParams } = options ?? {}
     return this.withOpsChannel(async (ch) => {
       const res = await ch.queueDeclare(name, declarationParams, queueArguments)

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -1067,22 +1067,28 @@ test("ops channel: passive NOT_FOUND doesn't disrupt concurrent declares", () =>
   }))
 
 test("ops channel: PRECONDITION_FAILED on mismatched declare doesn't disrupt siblings", () =>
-  withSession(async (session) => {
-    // Declare with one set of args, then attempt a conflicting declare
-    // concurrently with an unrelated declare. The conflict closes the
-    // channel — without the mutex the sibling declare fails too.
+  withSession(async (owner) => {
+    // Declare the queue from one session, then from a second session declare
+    // it with conflicting args concurrently with an unrelated declare. The
+    // conflict closes the second session's ops channel — without the mutex
+    // the sibling declare would fail too. Two sessions because cache-wins
+    // makes a same-session re-declare a no-op.
     const name = "test-precondition-" + Math.random()
-    await session.queue(name, { durable: false, autoDelete: true })
+    const queue = await owner.queue(name, { durable: false, autoDelete: true })
+    try {
+      await withSession(async (session) => {
+        const okName = "test-precondition-sibling-" + Math.random()
+        const results = await Promise.allSettled([
+          session.queue(name, { durable: true }),
+          session.queue(okName, { durable: false, autoDelete: true }),
+        ])
 
-    const okName = "test-precondition-sibling-" + Math.random()
-    const results = await Promise.allSettled([
-      // Re-declare with conflicting args → PRECONDITION_FAILED → channel close.
-      session.queue(name, { durable: true }),
-      session.queue(okName, { durable: false, autoDelete: true }),
-    ])
-
-    expect(results[0]?.status).toBe("rejected")
-    expect(results[1]?.status).toBe("fulfilled")
+        expect(results[0]?.status).toBe("rejected")
+        expect(results[1]?.status).toBe("fulfilled")
+      })
+    } finally {
+      await queue.delete()
+    }
   }))
 
 test("subscription.cancel() swallows underlying consumer errors", () =>

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -307,6 +307,17 @@ test("session.queue() declares a queue and returns AMQPQueue", () =>
     expect(q.name).toMatch(/^test-sq-/)
   }))
 
+test("session.queue(name) with no options reuses cached handle without redeclaring", () =>
+  withSession(async (session) => {
+    const name = "test-sq-redecl-" + Math.random()
+    const first = await session.queue(name, { durable: false, autoDelete: true })
+    // Bare re-call would otherwise default durable: true (since name !== "")
+    // and trip PRECONDITION_FAILED against the durable: false original.
+    const second = await session.queue(name)
+    expect(second).toBe(first)
+    await first.delete()
+  }))
+
 test("AMQPQueue (session-backed).publish() and get() round-trip", () =>
   withSession(async (session) => {
     const q = await session.queue("test-sq-rtt-" + Math.random(), { durable: false, autoDelete: true })

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -307,14 +307,17 @@ test("session.queue() declares a queue and returns AMQPQueue", () =>
     expect(q.name).toMatch(/^test-sq-/)
   }))
 
-test("session.queue(name) with no options reuses cached handle without redeclaring", () =>
+test("session.queue(name) re-call returns cached handle without redeclaring", () =>
   withSession(async (session) => {
     const name = "test-sq-redecl-" + Math.random()
     const first = await session.queue(name, { durable: false, autoDelete: true })
-    // Bare re-call would otherwise default durable: true (since name !== "")
-    // and trip PRECONDITION_FAILED against the durable: false original.
+    // Without the cache, a bare re-call would default durable: true (since
+    // name !== "") and trip PRECONDITION_FAILED against the durable: false
+    // original. The same applies to a re-call with {}.
     const second = await session.queue(name)
+    const third = await session.queue(name, {})
     expect(second).toBe(first)
+    expect(third).toBe(first)
     await first.delete()
   }))
 


### PR DESCRIPTION
### WHY was this introduces?

queueDeclare defaults durable to `name !== ""`, so a second
`session.queue(name)` call with no options on a non-empty name
flips `durable: true` and results in a `PRECONDITION_FAILED`.

Steps to reproduce:
```
const session = await AMQPSession.connect("amqp://127.0.0.1")
await session.queue("foo", { durable: false, autoDelete: true })
await session.queue("foo")  // throws PRECONDITION_FAILED
```


### WHAT changes?
The previously declared queue si returned.

```
const a = await session.queue("foo", { durable: false, autoDelete: true })
const b = await session.queue("foo")
a === b  // true
```