### PR TITLE
session: log connect/disconnect/reconnect/failed via logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `session.onconnect` / `session.onfailed` lifecycle hooks
   - `session.closed` — `true` when the underlying connection is closed
   - `session.stop()` — cancels reconnection, clears all subscriptions, and closes the connection
+  - Lifecycle transitions log automatically via the configured logger: `info` on connect/reconnect, `warn` on disconnect, `error` when reconnect gives up. Messages are prefixed with `AMQPSession[${name}]:` when the URL carries `?name=` ([#219](https://github.com/cloudamqp/amqp-client.js/issues/219))
 - `AMQPQueue` — reconnect-safe queue handle returned by `session.queue()`, with `publish()`, `subscribe()`, `get()`, `bind()`, `unbind()`, `purge()`, `delete()` ([#186](https://github.com/cloudamqp/amqp-client.js/pull/186))
   - `subscribe(callback)` / `subscribe(params, callback)` — auto-acks after the callback returns; nacks and requeues on throw; call `msg.ack()` / `msg.nack()` inside the callback to override; pass `{ noAck: true }` to skip acking entirely; `requeueOnNack` controls requeue behaviour on error ([#189](https://github.com/cloudamqp/amqp-client.js/pull/189))
   - `subscribe()` / `subscribe(params)` — async-iterator form; auto-acks the previous message when the loop advances; the last message (after `break`) is left unacked; call `msg.ack()` / `msg.nack()` before advancing to override; pass `{ noAck: true }` to skip acking ([#189](https://github.com/cloudamqp/amqp-client.js/pull/189))

--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -165,6 +165,7 @@ export class AMQPSession<
       maxRetries: options?.maxRetries ?? 0,
     }
     this.client.ondisconnect = (err) => {
+      this.client.logger?.warn(`${this.logTag()}: disconnected`)
       this.opsChannel = null
       this.confirmChannel = null
       this.opsChannelPromise = null
@@ -174,6 +175,10 @@ export class AMQPSession<
         void this.reconnectLoop()
       }
     }
+  }
+
+  private logTag(): string {
+    return this.client.name ? `AMQPSession[${this.client.name}]` : "AMQPSession"
   }
 
   /**
@@ -206,14 +211,24 @@ export class AMQPSession<
       const vhost = options?.vhost ?? "/"
       const username = decodeURIComponent(u.username) || "guest"
       const password = decodeURIComponent(u.password) || "guest"
+      const name = u.searchParams.get("name") ?? undefined
       const wsUrl = `${u.protocol}//${u.host}${u.pathname}${u.search}`
-      client = new AMQPWebSocketClient({ url: wsUrl, vhost, username, password, logger: options?.logger ?? null })
+      const init: ConstructorParameters<typeof AMQPWebSocketClient>[0] = {
+        url: wsUrl,
+        vhost,
+        username,
+        password,
+        logger: options?.logger ?? null,
+      }
+      if (name) init.name = name
+      client = new AMQPWebSocketClient(init)
     } else {
       const { AMQPClient } = await import("./amqp-socket-client.js")
       client = new AMQPClient(url, options?.tlsOptions, options?.logger)
     }
     await client.connect()
     const session = new AMQPSession(client, options)
+    client.logger?.info(`${session.logTag()}: connected`)
     options?.onconnect?.()
     return session
   }
@@ -452,6 +467,7 @@ export class AMQPSession<
       // Give up after maxRetries
       if (this.options.maxRetries > 0 && this.reconnectAttempts > this.options.maxRetries) {
         this.stopped = true
+        this.client.logger?.error(`${this.logTag()}: reconnect gave up`)
         this.onfailed?.(new Error(`Max reconnection attempts (${this.options.maxRetries}) reached`))
         continue
       }
@@ -479,6 +495,7 @@ export class AMQPSession<
       await this.recoverQueues()
       if (this.stopped || this.client.closed) continue // stop() called, or connection dropped during recovery
 
+      this.client.logger?.info(`${this.logTag()}: reconnected`)
       this.onconnect?.()
       break
     }

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -221,6 +221,56 @@ test("ondisconnect fires when the connection drops", async () => {
   }
 })
 
+test("logger: logs initial connect, disconnect, reconnect with name prefix", async () => {
+  const info = vi.fn()
+  const warn = vi.fn()
+  const logger = { debug: vi.fn(), info, warn, error: vi.fn() }
+  let count = 0
+  let resolveReconnected!: () => void
+  const reconnected = new Promise<void>((resolve, reject) => {
+    resolveReconnected = resolve
+    setTimeout(() => reject(new Error("Reconnection timed out")), 10_000)
+  })
+  const session = await AMQPSession.connect("amqp://127.0.0.1?name=my-app", {
+    logger,
+    reconnectInterval: 50,
+    maxRetries: 5,
+    onconnect: () => {
+      count++
+      if (count === 2) resolveReconnected()
+    },
+  })
+  try {
+    expect(info).toHaveBeenCalledWith("AMQPSession[my-app]: connected")
+    ;(testClient(session) as AMQPClient).socket?.destroy()
+    await reconnected
+    expect(warn).toHaveBeenCalledWith("AMQPSession[my-app]: disconnected")
+    expect(info).toHaveBeenCalledWith("AMQPSession[my-app]: reconnected")
+  } finally {
+    await session.stop()
+  }
+})
+
+test("logger: logs reconnect gave up when maxRetries exhausted", async () => {
+  const error = vi.fn()
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error }
+  const session = await AMQPSession.connect("amqp://127.0.0.1", {
+    logger,
+    reconnectInterval: 50,
+    maxRetries: 2,
+  })
+  try {
+    const client = testClient(session)
+    const connectSpy = vi.spyOn(client, "connect").mockRejectedValue(new Error("forced failure"))
+    ;(client as AMQPClient).socket?.destroy()
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    expect(error).toHaveBeenCalledWith("AMQPSession: reconnect gave up")
+    connectSpy.mockRestore()
+  } finally {
+    await session.stop()
+  }
+})
+
 test("subscription recovers and receives messages after reconnection", async () => {
   let connectCount = 0
   let resolveReconnected!: () => void


### PR DESCRIPTION
## Background

Closes #219.

Every downstream user of `AMQPSession` who wants visibility into the connection lifecycle ends up wiring the same boilerplate:

```js
const session = await AMQPSession.connect(url, {
  onconnect: () => console.log('AMQP session connected'),
  onfailed: (err) => console.error('AMQP reconnect gave up', err),
})
```

The library already accepts a `logger` and already emits `debug`/`warn` from inside the reconnect loop. The state transitions — successful initial connect, successful reconnect, drop, and terminal "gave up" — go unlogged unless callers wire handlers themselves.

## Summary

- `AMQPSession` now logs state transitions automatically when a logger is configured:
  - initial connect → `info` → `AMQPSession[${name}]: connected`
  - reconnect after recovery → `info` → `AMQPSession[${name}]: reconnected`
  - connection drops → `warn` → `AMQPSession[${name}]: disconnected`
  - reconnect gives up → `error` → `AMQPSession[${name}]: reconnect gave up`
- `${name}` comes from the URL's `?name=` query param (also extracted for the WebSocket transport, which previously dropped it). Prefix omits the brackets when `?name=` is absent.
- `onconnect` / `ondisconnect` / `onfailed` keep their semantics — purely additive. `logger: null` still opts out of all library logging.

## Test plan

- [x] `npm run format:check` clean
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] New tests cover initial connect, drop+reconnect with name prefix, and "reconnect gave up" — all pass against local RabbitMQ
- [x] Existing reconnect/onconnect/onfailed/stop tests still pass