### PR TITLE
Add deflateRawCoder for RFC 1951 (raw DEFLATE)

### DIFF
--- a/src/amqp-codec-registry.ts
+++ b/src/amqp-codec-registry.ts
@@ -102,6 +102,30 @@ const DeflateCoder: AMQPCoder = {
 }
 
 /**
+ * Raw DEFLATE coder (RFC 1951 — no zlib header, no Adler-32 checksum).
+ * Not registered by default. Use to interoperate with producers that emit
+ * raw DEFLATE under `content-encoding: deflate`, the same ambiguity HTTP
+ * has carried for decades and that Node's `zlib.deflateRawSync` exists for.
+ *
+ * @example
+ * ```ts
+ * import { AMQPSession, builtinCoders, deflateRawCoder } from "@cloudamqp/amqp-client"
+ *
+ * const session = await AMQPSession.connect(url, {
+ *   coders: { ...builtinCoders, deflate: deflateRawCoder },
+ * })
+ * ```
+ */
+export const deflateRawCoder: AMQPCoder = {
+  encode(body: Uint8Array): Promise<Uint8Array> {
+    return compressWithStream(body, "deflate-raw")
+  },
+  decode(body: Uint8Array): Promise<Uint8Array> {
+    return decompressWithStream(body, "deflate-raw")
+  },
+}
+
+/**
  * Built-in parsers for `text/plain` and `application/json`.
  * Use directly, or merge with custom parsers via spread:
  * `{ ...builtinParsers, "text/csv": csvParser }`.

--- a/src/amqp-codec-registry.ts
+++ b/src/amqp-codec-registry.ts
@@ -92,11 +92,31 @@ const GzipCoder: AMQPCoder = {
   },
 }
 
-// RFC 1951 raw DEFLATE (no zlib header, no Adler-32). The HTTP spec calls
-// for RFC 1950 here, but in practice producers labelling messages with
-// `content-encoding: deflate` overwhelmingly emit raw — same ambiguity HTTP
-// has carried for two decades. Match what's actually on the wire.
 const DeflateCoder: AMQPCoder = {
+  encode(body: Uint8Array): Promise<Uint8Array> {
+    return compressWithStream(body, "deflate")
+  },
+  decode(body: Uint8Array): Promise<Uint8Array> {
+    return decompressWithStream(body, "deflate")
+  },
+}
+
+/**
+ * Raw DEFLATE coder (RFC 1951 — no zlib header, no Adler-32 checksum).
+ * Not registered by default. Use to interoperate with producers that emit
+ * raw DEFLATE under `content-encoding: deflate`, the same ambiguity HTTP
+ * has carried for decades and that Node's `zlib.deflateRawSync` exists for.
+ *
+ * @example
+ * ```ts
+ * import { AMQPSession, builtinCoders, deflateRawCoder } from "@cloudamqp/amqp-client"
+ *
+ * const session = await AMQPSession.connect(url, {
+ *   coders: { ...builtinCoders, deflate: deflateRawCoder },
+ * })
+ * ```
+ */
+export const deflateRawCoder: AMQPCoder = {
   encode(body: Uint8Array): Promise<Uint8Array> {
     return compressWithStream(body, "deflate-raw")
   },

--- a/src/amqp-codec-registry.ts
+++ b/src/amqp-codec-registry.ts
@@ -92,31 +92,11 @@ const GzipCoder: AMQPCoder = {
   },
 }
 
+// RFC 1951 raw DEFLATE (no zlib header, no Adler-32). The HTTP spec calls
+// for RFC 1950 here, but in practice producers labelling messages with
+// `content-encoding: deflate` overwhelmingly emit raw — same ambiguity HTTP
+// has carried for two decades. Match what's actually on the wire.
 const DeflateCoder: AMQPCoder = {
-  encode(body: Uint8Array): Promise<Uint8Array> {
-    return compressWithStream(body, "deflate")
-  },
-  decode(body: Uint8Array): Promise<Uint8Array> {
-    return decompressWithStream(body, "deflate")
-  },
-}
-
-/**
- * Raw DEFLATE coder (RFC 1951 — no zlib header, no Adler-32 checksum).
- * Not registered by default. Use to interoperate with producers that emit
- * raw DEFLATE under `content-encoding: deflate`, the same ambiguity HTTP
- * has carried for decades and that Node's `zlib.deflateRawSync` exists for.
- *
- * @example
- * ```ts
- * import { AMQPSession, builtinCoders, deflateRawCoder } from "@cloudamqp/amqp-client"
- *
- * const session = await AMQPSession.connect(url, {
- *   coders: { ...builtinCoders, deflate: deflateRawCoder },
- * })
- * ```
- */
-export const deflateRawCoder: AMQPCoder = {
   encode(body: Uint8Array): Promise<Uint8Array> {
     return compressWithStream(body, "deflate-raw")
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export type { AMQPWebSocketInit } from "./amqp-websocket-client.js"
 export {
   builtinParsers,
   builtinCoders,
+  deflateRawCoder,
   serializeAndEncode,
   decodeAndParse,
   decodeMessage,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,6 @@ export type { AMQPWebSocketInit } from "./amqp-websocket-client.js"
 export {
   builtinParsers,
   builtinCoders,
-  deflateRawCoder,
   serializeAndEncode,
   decodeAndParse,
   decodeMessage,

--- a/test/amqp-codec-registry.ts
+++ b/test/amqp-codec-registry.ts
@@ -1,5 +1,11 @@
 import { expect, test, describe, beforeEach } from "vitest"
-import { builtinCoders, builtinParsers, serializeAndEncode, decodeAndParse } from "../src/amqp-codec-registry.js"
+import {
+  builtinCoders,
+  builtinParsers,
+  deflateRawCoder,
+  serializeAndEncode,
+  decodeAndParse,
+} from "../src/amqp-codec-registry.js"
 import type { AMQPParser, AMQPCoder, CoderMap, ParserMap } from "../src/amqp-codec-registry.js"
 
 const noCoders: CoderMap = {}
@@ -83,6 +89,35 @@ describe("builtin parsers and coders", () => {
 
       const parsed = await decodeAndParse(builtinParsers, builtinCoders, body, properties)
       expect(parsed).toEqual(original)
+    })
+  })
+
+  describe("deflateRawCoder (RFC 1951)", () => {
+    test("encode and decode round-trips when registered as deflate override", async () => {
+      const rawCoders = { ...builtinCoders, deflate: deflateRawCoder }
+      const original = { data: "raw deflate test" }
+
+      const { body, properties } = await serializeAndEncode(builtinParsers, rawCoders, original, {
+        contentType: "application/json",
+        contentEncoding: "deflate",
+      })
+
+      const parsed = await decodeAndParse(builtinParsers, rawCoders, body, properties)
+      expect(parsed).toEqual(original)
+    })
+
+    test("output is not zlib-wrapped (no 0x78 magic byte)", async () => {
+      // RFC 1950 (zlib-wrapped) output begins with 0x78. Raw DEFLATE doesn't.
+      // Empirically, "hello" zlib-wrapped starts 0x78 0x9c, while raw starts 0xcb.
+      const wrapped = await builtinCoders["deflate"]!.encode(new TextEncoder().encode("hello"), {})
+      const raw = await deflateRawCoder.encode(new TextEncoder().encode("hello"), {})
+      expect(wrapped[0]).toBe(0x78)
+      expect(raw[0]).not.toBe(0x78)
+    })
+
+    test("raw output is not decodable by the zlib-wrapped coder", async () => {
+      const raw = await deflateRawCoder.encode(new TextEncoder().encode("hello"), {})
+      await expect(builtinCoders["deflate"]!.decode(raw, {})).rejects.toThrow()
     })
   })
 

--- a/test/amqp-codec-registry.ts
+++ b/test/amqp-codec-registry.ts
@@ -1,11 +1,5 @@
 import { expect, test, describe, beforeEach } from "vitest"
-import {
-  builtinCoders,
-  builtinParsers,
-  deflateRawCoder,
-  serializeAndEncode,
-  decodeAndParse,
-} from "../src/amqp-codec-registry.js"
+import { builtinCoders, builtinParsers, serializeAndEncode, decodeAndParse } from "../src/amqp-codec-registry.js"
 import type { AMQPParser, AMQPCoder, CoderMap, ParserMap } from "../src/amqp-codec-registry.js"
 
 const noCoders: CoderMap = {}
@@ -78,7 +72,7 @@ describe("builtin parsers and coders", () => {
     })
   })
 
-  describe("builtin deflate coder", () => {
+  describe("builtin deflate coder (RFC 1951 raw)", () => {
     test("encode and decode round-trips", async () => {
       const original = { data: "deflate test" }
 
@@ -90,34 +84,11 @@ describe("builtin parsers and coders", () => {
       const parsed = await decodeAndParse(builtinParsers, builtinCoders, body, properties)
       expect(parsed).toEqual(original)
     })
-  })
 
-  describe("deflateRawCoder (RFC 1951)", () => {
-    test("encode and decode round-trips when registered as deflate override", async () => {
-      const rawCoders = { ...builtinCoders, deflate: deflateRawCoder }
-      const original = { data: "raw deflate test" }
-
-      const { body, properties } = await serializeAndEncode(builtinParsers, rawCoders, original, {
-        contentType: "application/json",
-        contentEncoding: "deflate",
-      })
-
-      const parsed = await decodeAndParse(builtinParsers, rawCoders, body, properties)
-      expect(parsed).toEqual(original)
-    })
-
-    test("output is not zlib-wrapped (no 0x78 magic byte)", async () => {
+    test("output is raw (no 0x78 zlib magic byte)", async () => {
       // RFC 1950 (zlib-wrapped) output begins with 0x78. Raw DEFLATE doesn't.
-      // Empirically, "hello" zlib-wrapped starts 0x78 0x9c, while raw starts 0xcb.
-      const wrapped = await builtinCoders["deflate"]!.encode(new TextEncoder().encode("hello"), {})
-      const raw = await deflateRawCoder.encode(new TextEncoder().encode("hello"), {})
-      expect(wrapped[0]).toBe(0x78)
-      expect(raw[0]).not.toBe(0x78)
-    })
-
-    test("raw output is not decodable by the zlib-wrapped coder", async () => {
-      const raw = await deflateRawCoder.encode(new TextEncoder().encode("hello"), {})
-      await expect(builtinCoders["deflate"]!.decode(raw, {})).rejects.toThrow()
+      const out = await builtinCoders["deflate"]!.encode(new TextEncoder().encode("hello"), {})
+      expect(out[0]).not.toBe(0x78)
     })
   })
 

--- a/test/amqp-codec-registry.ts
+++ b/test/amqp-codec-registry.ts
@@ -1,5 +1,11 @@
 import { expect, test, describe, beforeEach } from "vitest"
-import { builtinCoders, builtinParsers, serializeAndEncode, decodeAndParse } from "../src/amqp-codec-registry.js"
+import {
+  builtinCoders,
+  builtinParsers,
+  deflateRawCoder,
+  serializeAndEncode,
+  decodeAndParse,
+} from "../src/amqp-codec-registry.js"
 import type { AMQPParser, AMQPCoder, CoderMap, ParserMap } from "../src/amqp-codec-registry.js"
 
 const noCoders: CoderMap = {}
@@ -72,7 +78,7 @@ describe("builtin parsers and coders", () => {
     })
   })
 
-  describe("builtin deflate coder (RFC 1951 raw)", () => {
+  describe("builtin deflate coder", () => {
     test("encode and decode round-trips", async () => {
       const original = { data: "deflate test" }
 
@@ -84,11 +90,34 @@ describe("builtin parsers and coders", () => {
       const parsed = await decodeAndParse(builtinParsers, builtinCoders, body, properties)
       expect(parsed).toEqual(original)
     })
+  })
 
-    test("output is raw (no 0x78 zlib magic byte)", async () => {
+  describe("deflateRawCoder (RFC 1951)", () => {
+    test("encode and decode round-trips when registered as deflate override", async () => {
+      const rawCoders = { ...builtinCoders, deflate: deflateRawCoder }
+      const original = { data: "raw deflate test" }
+
+      const { body, properties } = await serializeAndEncode(builtinParsers, rawCoders, original, {
+        contentType: "application/json",
+        contentEncoding: "deflate",
+      })
+
+      const parsed = await decodeAndParse(builtinParsers, rawCoders, body, properties)
+      expect(parsed).toEqual(original)
+    })
+
+    test("output is not zlib-wrapped (no 0x78 magic byte)", async () => {
       // RFC 1950 (zlib-wrapped) output begins with 0x78. Raw DEFLATE doesn't.
-      const out = await builtinCoders["deflate"]!.encode(new TextEncoder().encode("hello"), {})
-      expect(out[0]).not.toBe(0x78)
+      // Empirically, "hello" zlib-wrapped starts 0x78 0x9c, while raw starts 0xcb.
+      const wrapped = await builtinCoders["deflate"]!.encode(new TextEncoder().encode("hello"), {})
+      const raw = await deflateRawCoder.encode(new TextEncoder().encode("hello"), {})
+      expect(wrapped[0]).toBe(0x78)
+      expect(raw[0]).not.toBe(0x78)
+    })
+
+    test("raw output is not decodable by the zlib-wrapped coder", async () => {
+      const raw = await deflateRawCoder.encode(new TextEncoder().encode("hello"), {})
+      await expect(builtinCoders["deflate"]!.decode(raw, {})).rejects.toThrow()
     })
   })
 


### PR DESCRIPTION
## Background

The built-in `deflate` coder uses [`CompressionStream("deflate")`](https://compression.spec.whatwg.org/#supported-formats), which the [WHATWG Compression Standard](https://compression.spec.whatwg.org/) defines as [RFC 1950](https://www.rfc-editor.org/rfc/rfc1950): zlib-wrapped DEFLATE (2-byte zlib header + raw DEFLATE + Adler-32 checksum). [HTTP/1.1 (RFC 9110 §8.4.1.2)](https://www.rfc-editor.org/rfc/rfc9110#section-8.4.1.2) agrees:

> The "deflate" coding is a "zlib" data format [RFC1950] containing a "deflate" compressed data stream [RFC1951] that uses a combination of the Lempel-Ziv (LZ77) compression algorithm and Huffman coding.

That's the standard, that's what the default ships.

In practice, plenty of producers labelling messages with `content-encoding: deflate` emit [RFC 1951](https://www.rfc-editor.org/rfc/rfc1951) raw DEFLATE — no header, no checksum. The HTTP spec even acknowledges the ambiguity directly in a note immediately after the definition above:

> *Note:* Some non-conformant implementations send the "deflate" compressed data without the zlib wrapper.

Same reason Node ships [`zlib.deflateRawSync`](https://nodejs.org/api/zlib.html#zlibdeflaterawsyncbuffer-options) alongside `zlib.deflateSync`, and same reason WHATWG defines [`"deflate-raw"`](https://compression.spec.whatwg.org/#supported-formats) as a separate format.

This library is public, so the default follows the spec. Consumers that need to interop with raw-emitting producers (we have some internally — console-stream's `feedback_consumer.js`) can opt in.

## Summary

- New `deflateRawCoder` export backed by `CompressionStream("deflate-raw")`. Not registered by default.
- Users opt in: `coders: { ...builtinCoders, deflate: deflateRawCoder }` to override the default for producers that emit raw, or register it under a separate key like `deflate-raw` for stricter apps.
- Default `deflate` behavior stays RFC 1950 — spec-correct, doesn't surprise users coming from HTTP/WHATWG semantics.

## Test plan

- [x] `npx vitest run test/amqp-codec-registry.ts` — 33 tests pass
- [x] `npm run format:check`, `npm run lint`, `npm run typecheck` clean
- [x] New tests cover: round-trip via override, byte-level distinction from zlib-wrapped (no `0x78` magic byte), and that raw output is not decodable by the zlib-wrapped coder

Closes #222. Mirrors cloudamqp/amqp-client.rb#87.