### PR TITLE
session: support server-named queues across reconnect

### DIFF
--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -1,5 +1,5 @@
 import type { AMQPMessage } from "./amqp-message.js"
-import type { ConsumeParams, MessageCount } from "./amqp-channel.js"
+import type { ConsumeParams, MessageCount, QueueParams } from "./amqp-channel.js"
 import type { AMQPProperties } from "./amqp-properties.js"
 import { AMQPConsumer, AMQPGeneratorConsumer } from "./amqp-consumer.js"
 import { AMQPSubscription, AMQPGeneratorSubscription } from "./amqp-subscription.js"
@@ -9,6 +9,33 @@ import type { AMQPExchange } from "./amqp-exchange.js"
 import type { ResolveBody } from "./amqp-publisher.js"
 import { serializeAndEncode, decodeMessage } from "./amqp-codec-registry.js"
 import type { ParserMap, CoderMap } from "./amqp-codec-registry.js"
+
+/**
+ * Recovery metadata captured at declare time so the session can replay the
+ * declare on reconnect.
+ * @internal
+ */
+export interface QueueRecovery {
+  /**
+   * `true` when the broker generated the queue name (declared with `""`).
+   * Recovery tries a passive declare with the captured name; if the queue is
+   * gone (broker restart, exclusive queue dropped with the old connection)
+   * we redeclare anonymously and adopt the new broker-assigned name.
+   */
+  serverNamed: boolean
+  /** Declaration params used at initial declare — replayed on rename. */
+  params: QueueParams
+  /** Arguments table from initial declare — replayed on rename. */
+  args?: Record<string, unknown>
+  /** Fires after a reconnect-driven rename with the new broker-assigned name. */
+  onName?: (newName: string) => void
+}
+
+type Binding = {
+  exchange: string
+  routingKey: string
+  args: Record<string, unknown>
+}
 
 /**
  * Options for {@link AMQPQueue#subscribe}.
@@ -45,15 +72,27 @@ export class AMQPQueue<
   KP extends keyof P & string = never,
   KC extends keyof C & string = never,
 > {
-  /** Queue name. */
-  readonly name: string
+  // Mutable so server-named queues can be re-declared with a new broker-assigned
+  // name after a reconnect without forcing callers to re-fetch the handle.
+  private currentName: string
   private readonly session: AMQPSession<P, C, KP, KC>
   private readonly subscriptions = new Set<AMQPSubscription>()
+  private readonly recovery: QueueRecovery
+  // Bindings registered through this handle. Replayed only on the rename path
+  // (server-named queue lost across reconnect) — bindings on a queue that
+  // survived already exist on the broker side.
+  private readonly bindings: Binding[] = []
+
+  /** Queue name. For server-named queues this reflects the most recent broker-assigned name. */
+  get name(): string {
+    return this.currentName
+  }
 
   /** @internal */
-  constructor(session: AMQPSession<P, C, KP, KC>, name: string) {
+  constructor(session: AMQPSession<P, C, KP, KC>, name: string, recovery?: QueueRecovery) {
     this.session = session
-    this.name = name
+    this.currentName = name
+    this.recovery = recovery ?? { serverNamed: false, params: {} }
   }
 
   /**
@@ -257,6 +296,10 @@ export class AMQPQueue<
 
   /**
    * Bind this queue to an exchange.
+   *
+   * For server-named queues, the binding is tracked so it can be re-established
+   * on the new queue if the broker hands out a fresh name after reconnect.
+   *
    * @returns `this` for chaining
    */
   async bind(
@@ -266,6 +309,7 @@ export class AMQPQueue<
   ): Promise<AMQPQueue<P, C, KP, KC>> {
     const exchangeName = typeof exchange === "string" ? exchange : exchange.name
     await this.session.withOpsChannel((ch) => ch.queueBind(this.name, exchangeName, routingKey, args))
+    if (this.recovery.serverNamed) this.bindings.push({ exchange: exchangeName, routingKey, args })
     return this
   }
 
@@ -280,7 +324,16 @@ export class AMQPQueue<
   ): Promise<AMQPQueue<P, C, KP, KC>> {
     const exchangeName = typeof exchange === "string" ? exchange : exchange.name
     await this.session.withOpsChannel((ch) => ch.queueUnbind(this.name, exchangeName, routingKey, args))
+    if (this.recovery.serverNamed) this.removeTrackedBinding(exchangeName, routingKey, args)
     return this
+  }
+
+  private removeTrackedBinding(exchange: string, routingKey: string, args: Record<string, unknown>): void {
+    const argsKey = JSON.stringify(args)
+    const idx = this.bindings.findIndex(
+      (b) => b.exchange === exchange && b.routingKey === routingKey && JSON.stringify(b.args) === argsKey,
+    )
+    if (idx >= 0) this.bindings.splice(idx, 1)
   }
 
   /** Purge all messages from this queue. */
@@ -298,12 +351,19 @@ export class AMQPQueue<
   }
 
   /**
-   * Re-establish all subscriptions after a reconnection.
+   * Re-establish the queue and all its subscriptions after a reconnection.
+   * For server-named queues, this also handles re-declaring under a new
+   * broker-assigned name and replaying tracked bindings.
    * @internal Called by the session's reconnect loop.
    */
   async recover(): Promise<void> {
+    if (this.recovery.serverNamed) {
+      const renamed = await this.recoverServerNamedQueue()
+      if (renamed === null) return // both passive and fresh declare failed; skip consumer recovery
+    }
     for (const sub of this.subscriptions) {
       try {
+        sub.def.queueName = this.name
         const consumer = await this.openConsumer(sub.def)
         sub.setConsumer(consumer)
         this.session.logger?.debug(`Recovered consumer for queue: ${this.name}`)
@@ -312,6 +372,50 @@ export class AMQPQueue<
         this.session.logger?.warn(`Failed to recover consumer for queue ${this.name}:`, error.message)
       }
     }
+  }
+
+  // Returns the (possibly new) queue name on success, null on declare failure.
+  // Carl on #210: "you're not allowed to declare a queue starting with 'amq.'"
+  // (the broker reserves that prefix for itself), so the broker-assigned name
+  // can never be reused — we always pass "" when redeclaring.
+  private async recoverServerNamedQueue(): Promise<string | null> {
+    const oldName = this.currentName
+    try {
+      await this.session.withOpsChannel((ch) => ch.queueDeclare(oldName, { passive: true }))
+      return oldName
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err))
+      this.session.logger?.debug(`Server-named queue ${oldName} gone after reconnect (${error.message}); redeclaring`)
+    }
+    let newName: string
+    try {
+      newName = await this.session.withOpsChannel(async (ch) => {
+        const res = await ch.queueDeclare("", this.recovery.params, this.recovery.args)
+        return res.name
+      })
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err))
+      this.session.logger?.warn(`Failed to redeclare server-named queue (was ${oldName}):`, error.message)
+      return null
+    }
+    this.currentName = newName
+    this.session.renameQueue(oldName, newName, this)
+    this.session.logger?.info(`Server-named queue renamed across reconnect: ${oldName} -> ${newName}`)
+    this.recovery.onName?.(newName)
+    // Best-effort bind replay — losing one binding (e.g., the exchange went
+    // away) shouldn't block consumer recovery on the new queue.
+    for (const b of this.bindings) {
+      try {
+        await this.session.withOpsChannel((ch) => ch.queueBind(newName, b.exchange, b.routingKey, b.args))
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err))
+        this.session.logger?.warn(
+          `Failed to replay binding ${newName} -> ${b.exchange} (${b.routingKey || "<no key>"}):`,
+          error.message,
+        )
+      }
+    }
+    return newName
   }
 
   /**

--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -11,6 +11,13 @@ import type { AMQPChannel, ExchangeParams, ExchangeType, QueueParams } from "./a
 export type QueueOptions = QueueParams & {
   /** Queue arguments table (e.g. `{ "x-delivery-limit": 3 }`). */
   arguments?: Record<string, unknown>
+  /**
+   * Fires for server-named queues (declared with `""`) when the broker hands
+   * out a new name after a reconnect. Most consumers just keep reading from
+   * the handle, which auto-updates — register this only when something
+   * outside the handle has cached the name.
+   */
+  onName?: (newName: string) => void
 }
 
 /**
@@ -27,6 +34,7 @@ import type { ParserMap, CoderMap, ParserRegistry, CoderRegistry } from "./amqp-
 import type { AMQPProperties } from "./amqp-properties.js"
 import type { ResolveBody } from "./amqp-publisher.js"
 import { AMQPQueue } from "./amqp-queue.js"
+import type { QueueRecovery } from "./amqp-queue.js"
 import type { AMQPTlsOptions } from "./amqp-tls-options.js"
 import type { Logger } from "./types.js"
 import { AMQPExchange } from "./amqp-exchange.js"
@@ -315,6 +323,13 @@ export class AMQPSession<
    *
    * Subsequent calls with the same name return the cached handle without
    * redeclaring, and `options` on those calls are ignored.
+   *
+   * Pass `""` for `name` to get a server-named queue. The returned handle's
+   * `.name` reflects the broker-assigned name and is updated in place if the
+   * broker hands out a new name after a reconnect; tracked `bind()` calls are
+   * replayed against the new name. Register `options.onName` to be notified
+   * when this happens.
+   *
    * @param name - queue name (use "" to let the broker generate a name)
    * @param [options] - queue declaration parameters and queue arguments
    */
@@ -323,15 +338,27 @@ export class AMQPSession<
       const cached = this.queues.get(name)
       if (cached) return cached
     }
-    const { arguments: queueArguments, ...declarationParams } = options ?? {}
+    const { arguments: queueArguments, onName, ...declarationParams } = options ?? {}
     return this.withOpsChannel(async (ch) => {
       const res = await ch.queueDeclare(name, declarationParams, queueArguments)
       const existing = this.queues.get(res.name)
       if (existing) return existing
-      const q = new AMQPQueue<P, C, KP, KC>(this, res.name)
+      const recovery: QueueRecovery = {
+        serverNamed: name === "",
+        params: declarationParams,
+        ...(queueArguments && { args: queueArguments }),
+        ...(onName && { onName }),
+      }
+      const q = new AMQPQueue<P, C, KP, KC>(this, res.name, recovery)
       this.queues.set(res.name, q)
       return q
     })
+  }
+
+  /** @internal Update the session's queue map after a server-named queue is renamed. */
+  renameQueue(oldName: string, newName: string, queue: AMQPQueue<P, C, KP, KC>): void {
+    if (this.queues.get(oldName) === queue) this.queues.delete(oldName)
+    this.queues.set(newName, queue)
   }
 
   /**
@@ -526,7 +553,9 @@ export class AMQPSession<
 
   private async recoverQueues(): Promise<void> {
     if (this.client.closed) return
-    for (const queue of this.queues.values()) {
+    // Snapshot before iterating — recover() can mutate the map for renamed
+    // server-named queues (renameQueue updates the key).
+    for (const queue of Array.from(this.queues.values())) {
       await queue.recover()
     }
     for (const rpc of this.rpcClients) {

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -429,6 +429,78 @@ test("AMQPExchange.publish() honors explicit deliveryMode: 1 (transient)", () =>
     expect(msg?.properties.deliveryMode).toBe(1)
   }))
 
+test("server-named queue: handle survives reconnect, bindings replayed, onName fires", async () => {
+  let connectCount = 0
+  let resolveReconnected!: () => void
+  const reconnected = new Promise<void>((resolve, reject) => {
+    resolveReconnected = resolve
+    setTimeout(() => reject(new Error("reconnect timed out")), 10_000)
+  })
+  const renames: { from: string; to: string }[] = []
+  await withSession(
+    async (session) => {
+      // durable + non-autoDelete so the exchange survives the disconnect — the
+      // exclusive queue's binding goes away with it, which would otherwise
+      // autoDelete the exchange and break the post-reconnect bind replay.
+      const exchange = await session.fanoutExchange("test-sn-fanout-" + Math.random(), {
+        durable: false,
+        autoDelete: false,
+      })
+
+      let onNameLatest = ""
+      const q = await session.queue("", {
+        exclusive: true,
+        autoDelete: true,
+        onName: (name) => {
+          onNameLatest = name
+        },
+      })
+      const initialName = q.name
+      expect(initialName).not.toBe("")
+
+      await q.bind(exchange)
+      const received: string[] = []
+      const sub = await q.subscribe({ noAck: true }, (msg) => {
+        received.push(msg.bodyString() ?? "")
+      })
+
+      await exchange.publish("before-disconnect")
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      ;(testClient(session) as AMQPClient).socket?.destroy()
+      await reconnected
+
+      // Exclusive queue died with the previous connection — broker hands out a new name.
+      expect(q.name).not.toBe(initialName)
+      expect(onNameLatest).toBe(q.name)
+      renames.push({ from: initialName, to: q.name })
+
+      await exchange.publish("after-reconnect")
+      await new Promise((resolve) => setTimeout(resolve, 200))
+
+      expect(received).toContain("after-reconnect")
+
+      await sub.cancel()
+      await exchange.delete()
+    },
+    {
+      reconnectInterval: 50,
+      maxRetries: 5,
+      onconnect: () => {
+        connectCount++
+        if (connectCount === 2) resolveReconnected()
+      },
+    },
+  )
+  expect(renames).toHaveLength(1)
+})
+
+test("server-named queue: AMQPQueue.name reflects broker-assigned name", () =>
+  withSession(async (session) => {
+    const q = await session.queue("", { exclusive: true, autoDelete: true })
+    expect(q.name).not.toBe("")
+    expect(q.name.length).toBeGreaterThan(0)
+  }))
+
 test("AMQPQueue (session-backed).subscribe() recovers after reconnect", async () => {
   let connectCount = 0
   let resolveReconnected!: () => void


### PR DESCRIPTION
## Background

Closes #210.

The natural shape — `session.queue("", { exclusive: true, autoDelete: true })` bound to a fanout exchange for fast-path signals — worked the first time but broke on reconnect. The handle stored the broker-assigned `amq.gen-...` name; recovery tried to redeclare that name verbatim; the broker rejected it (reserved prefix); bindings vanished; consumers never came back. The autoscaler had to drop back to `AMQPClient` to keep going, losing the parser registry, auto-ack, and recovery story along with it.

## Summary

- `AMQPQueue.name` is now a getter backed by a mutable field — server-named queues can be re-declared in place.
- `AMQPQueue` keeps the declare params + arguments it was created with, plus any bindings registered via `queue.bind()`.
- On recovery for a server-named queue: passive-declare the captured name first (per @carlhoerberg's note that `amq.*` names can't be redeclared explicitly); if that fails, redeclare anonymously, adopt the new name, replay tracked bindings best-effort, then re-attach consumers.
- `QueueOptions.onName?(newName)` fires after a rename for callers that have cached the name outside the handle.
- `AMQPSession` updates its queue map key on rename and snapshots `queues.values()` before iterating in `recoverQueues()` so the mutation is safe.
- Bindings registered through `queue.unbind()` are removed from the tracked list. Channel-bypass bindings are not tracked (per #210 open question — too easy to leak).

## Test plan

- [x] `server-named queue: handle survives reconnect, bindings replayed, onName fires` — declares an empty-named exclusive queue bound to a fanout, drops the socket, asserts the new name, that `onName` saw it, and that a post-reconnect publish through the exchange is delivered.
- [x] `server-named queue: AMQPQueue.name reflects broker-assigned name` — initial declare returns a non-empty name.
- [x] All 76 existing `test/amqp-session.ts` tests still pass.
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` clean.