### PR TITLE
queue: invalidate session cache on delete()

### DIFF
--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -294,7 +294,10 @@ export class AMQPQueue<
    * @param [params.ifEmpty=false] - only delete if the queue is empty
    */
   async delete(params?: { ifUnused?: boolean; ifEmpty?: boolean }): Promise<MessageCount> {
-    return this.session.withOpsChannel((ch) => ch.queueDelete(this.name, params))
+    const result = await this.session.withOpsChannel((ch) => ch.queueDelete(this.name, params))
+    this.cancelAll()
+    this.session.removeQueue(this.name)
+    return result
   }
 
   /**

--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -309,6 +309,17 @@ export class AMQPSession<
   }
 
   /**
+   * Remove a queue handle from the session cache. Called by
+   * {@link AMQPQueue#delete} after the broker acks the delete so subsequent
+   * `session.queue(name)` calls don't hand back a handle to a queue that no
+   * longer exists.
+   * @internal
+   */
+  removeQueue(name: string): void {
+    this.queues.delete(name)
+  }
+
+  /**
    * Declare a queue and return a session-bound {@link AMQPQueue} handle.
    * The returned queue's `subscribe` uses auto-recovery and `publish` waits for
    * a broker confirm.

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -371,6 +371,59 @@ test("session.queue(name) re-call returns cached handle without redeclaring", ()
     await first.delete()
   }))
 
+test("queue.delete() invalidates the session cache so re-declare returns a fresh handle", () =>
+  withSession(async (session) => {
+    const name = "test-sq-delete-cache-" + Math.random()
+    const first = await session.queue(name, { durable: false, autoDelete: true })
+    await first.delete()
+    // After delete, the cache entry must be gone — re-declaring with
+    // different params would otherwise return the stale handle and skip
+    // the new declare entirely.
+    const second = await session.queue(name, { durable: false, autoDelete: true })
+    expect(second).not.toBe(first)
+    await second.delete()
+  }))
+
+test("queue.delete() lets a re-declare succeed with conflicting params (cache cleared)", () =>
+  withSession(async (session) => {
+    const name = "test-sq-delete-redecl-" + Math.random()
+    const first = await session.queue(name, { durable: false, autoDelete: true, exclusive: false })
+    await first.delete()
+    // If the cache were still populated, this call would hand back `first`
+    // without redeclaring; with the cache cleared the broker accepts the
+    // fresh declaration with a different `exclusive` value.
+    const second = await session.queue(name, { durable: false, autoDelete: true, exclusive: true })
+    expect(second).not.toBe(first)
+    await second.delete()
+  }))
+
+test("queue.delete() cancels active subscriptions", () =>
+  withSession(async (session) => {
+    const name = "test-sq-delete-cancel-" + Math.random()
+    const q = await session.queue(name, { durable: false, autoDelete: false })
+    const sub = await q.subscribe(() => {})
+    const ch = sub.channel
+    expect(ch.closed).toBe(false)
+    await q.delete()
+    // cancelAll runs synchronously but the consumer cancel + channel close
+    // are async; wait a tick for the broker round-trip.
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(ch.closed).toBe(true)
+  }))
+
+test("queue.delete() failure keeps the cache entry (handle still usable)", () =>
+  withSession(async (session) => {
+    const name = "test-sq-delete-fail-" + Math.random()
+    const q = await session.queue(name, { durable: false, autoDelete: true })
+    await q.publish("blocker")
+    // ifEmpty against a non-empty queue → PRECONDITION_FAILED. Cache must
+    // stay intact since the queue still exists broker-side.
+    await expect(q.delete({ ifEmpty: true })).rejects.toThrow()
+    const again = await session.queue(name)
+    expect(again).toBe(q)
+    await q.delete()
+  }))
+
 test("AMQPQueue (session-backed).publish() and get() round-trip", () =>
   withSession(async (session) => {
     const q = await session.queue("test-sq-rtt-" + Math.random(), { durable: false, autoDelete: true })


### PR DESCRIPTION
## Summary
- `AMQPQueue.delete()` now drops itself from the session's queue cache and cancels local subscriptions after the broker acks. Without this, `session.queue(name)` returned a dead handle pointing at a non-existent broker queue, the reconnect loop tried to re-subscribe on it, and subscription channels leaked since broker-driven consumer cancel leaves the dedicated channel open.
- Broker call runs first — `ifEmpty`/`ifUnused` rejections keep the cache intact and the handle usable.
- New internal `AMQPSession.removeQueue(name)` accessor keeps the `queues` map private while letting the queue handle invalidate itself.

## Test plan
- [x] `npx vitest run test/amqp-session.ts` — 78 tests pass, including 4 new specs:
  - re-declare after delete returns a fresh handle
  - conflicting declare params accepted after delete (proves cache cleared)
  - subscription channel closes on delete
  - cache entry survives a broker-rejected delete (`ifEmpty` against a non-empty queue)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
