### PR TITLE
session: pass session to onconnect

### DIFF
--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -71,11 +71,22 @@ export interface AMQPSessionOptions<
    */
   vhost?: string
   /**
-   * Fires after a successful connection — both the initial connect and every
-   * reconnect after consumer recovery completes. Registering here rather than
-   * after `connect()` resolves means a single handler covers both code paths.
+   * Fires after a successful (re)connection — both the initial connect and
+   * every reconnect after consumer recovery completes. Registering here
+   * rather than after `connect()` resolves means a single handler covers
+   * both code paths.
+   *
+   * The session is passed in because on the initial connect this fires
+   * before the `connect()` call returns, so closures over the outer
+   * `session` variable would still see `undefined`. Use the argument —
+   * it's the same instance either way.
+   *
+   * Fire-and-forget. If your handler does async setup that the rest of
+   * your code depends on, drive it yourself (e.g. `await setup(session)`
+   * after `connect()` resolves) and use `onconnect` to re-run it on
+   * reconnects.
    */
-  onconnect?: () => void
+  onconnect?(session: AMQPSession<P, C, KP, KC>): void
   /**
    * Fires when the underlying connection drops, before the reconnect loop
    * starts. Useful for visibility into the gap between disconnect and
@@ -102,7 +113,7 @@ export class AMQPSession<
   KP extends keyof P & string = never,
   KC extends keyof C & string = never,
 > {
-  private readonly onconnect?: () => void
+  private readonly onconnect?: (session: AMQPSession<P, C, KP, KC>) => void
   private readonly ondisconnect?: (error?: Error) => void
   private readonly onfailed?: (error?: Error) => void
 
@@ -189,16 +200,6 @@ export class AMQPSession<
    * - `ws://` / `wss://` → WebSocket (`AMQPWebSocketClient`)
    */
   static async connect<
-    P extends ParserMap,
-    C extends CoderMap,
-    KP extends keyof P & string = never,
-    KC extends keyof C & string = never,
-  >(
-    url: string,
-    options: AMQPSessionOptions<P, C, KP, KC> & { parsers: ParserRegistry<P> },
-  ): Promise<AMQPSession<P, C, KP, KC>>
-  static async connect(url: string, options?: AMQPSessionOptions): Promise<AMQPSession>
-  static async connect<
     P extends ParserMap = {},
     C extends CoderMap = {},
     KP extends keyof P & string = never,
@@ -229,7 +230,7 @@ export class AMQPSession<
     await client.connect()
     const session = new AMQPSession(client, options)
     client.logger?.info(`${session.logTag()}: connected`)
-    options?.onconnect?.()
+    options?.onconnect?.(session)
     return session
   }
 
@@ -514,7 +515,7 @@ export class AMQPSession<
       if (this.stopped || this.client.closed) continue // stop() called, or connection dropped during recovery
 
       this.client.logger?.info(`${this.logTag()}: reconnected`)
-      this.onconnect?.()
+      this.onconnect?.(this)
       break
     }
 

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi, beforeEach } from "vitest"
 import { AMQPClient } from "../src/amqp-socket-client.js"
 import { AMQPSession } from "../src/amqp-session.js"
+import type { AMQPSessionOptions } from "../src/amqp-session.js"
 import { AMQPQueue } from "../src/amqp-queue.js"
 import { AMQPExchange } from "../src/amqp-exchange.js"
 import { AMQPMessage } from "../src/amqp-message.js"
@@ -17,10 +18,7 @@ function testClient(session: AMQPSession): AMQPBaseClient {
   return (session as unknown as { client: AMQPBaseClient }).client
 }
 
-async function withSession(
-  fn: (session: AMQPSession) => Promise<void>,
-  options?: Parameters<typeof AMQPSession.connect>[1],
-): Promise<void> {
+async function withSession(fn: (session: AMQPSession) => Promise<void>, options?: AMQPSessionOptions): Promise<void> {
   const session = await AMQPSession.connect("amqp://127.0.0.1", options)
   try {
     await fn(session)
@@ -183,6 +181,38 @@ test("onconnect fires on the initial connect", async () => {
   }
 })
 
+test("onconnect receives the session — usable on initial connect before AMQPSession.connect() returns", async () => {
+  // The pattern this enables: declare a server-named queue once inside
+  // `onconnect` and trust the same handler will re-run on every reconnect.
+  // No chicken-and-egg with the outer `session` variable.
+  const names: string[] = []
+  let resolveFirst!: () => void
+  let resolveSecond!: () => void
+  const firstReady = new Promise<void>((r) => (resolveFirst = r))
+  const secondReady = new Promise<void>((r) => (resolveSecond = r))
+  const session = await AMQPSession.connect("amqp://127.0.0.1", {
+    reconnectInterval: 50,
+    maxRetries: 5,
+    onconnect: (s) => {
+      void (async () => {
+        const q = await s.queue("", { exclusive: true, autoDelete: true })
+        names.push(q.name)
+        ;(names.length === 1 ? resolveFirst : resolveSecond)()
+      })()
+    },
+  })
+  try {
+    await firstReady
+    expect(names).toHaveLength(1)
+    ;(testClient(session) as AMQPClient).socket?.destroy()
+    await secondReady
+    expect(names).toHaveLength(2)
+    expect(names[0]).not.toBe(names[1])
+  } finally {
+    await session.stop()
+  }
+})
+
 test("onconnect fires after successful reconnection", async () => {
   let count = 0
   const reconnected = new Promise<void>((resolve, reject) => {
@@ -222,23 +252,20 @@ test("ondisconnect fires when the connection drops", async () => {
 })
 
 test("logger: logs initial connect, disconnect, reconnect with name prefix", async () => {
-  const info = vi.fn()
-  const warn = vi.fn()
-  const logger = { debug: vi.fn(), info, warn, error: vi.fn() }
-  let count = 0
   let resolveReconnected!: () => void
   const reconnected = new Promise<void>((resolve, reject) => {
     resolveReconnected = resolve
     setTimeout(() => reject(new Error("Reconnection timed out")), 10_000)
   })
+  const info = vi.fn((msg: string) => {
+    if (msg === "AMQPSession[my-app]: reconnected") resolveReconnected()
+  })
+  const warn = vi.fn()
+  const logger = { debug: vi.fn(), info, warn, error: vi.fn() }
   const session = await AMQPSession.connect("amqp://127.0.0.1?name=my-app", {
     logger,
     reconnectInterval: 50,
     maxRetries: 5,
-    onconnect: () => {
-      count++
-      if (count === 2) resolveReconnected()
-    },
   })
   try {
     expect(info).toHaveBeenCalledWith("AMQPSession[my-app]: connected")

--- a/test/type-safety.ts
+++ b/test/type-safety.ts
@@ -7,7 +7,7 @@
  * types change in a way that breaks the contract, tsc will flag them.
  */
 import { test, expectTypeOf } from "vitest"
-import type { AMQPSession } from "../src/amqp-session.js"
+import { AMQPSession } from "../src/amqp-session.js"
 import type { AMQPQueue } from "../src/amqp-queue.js"
 import type { AMQPExchange } from "../src/amqp-exchange.js"
 import type { AMQPRPCClient } from "../src/amqp-rpc-client.js"
@@ -227,4 +227,63 @@ test("CoderRegistry preserves keys in type", () => {
   type R = CoderRegistry<{ custom: AMQPCoder } & { gzip: AMQPCoder }>
   expectTypeOf<R["gzip"]>().toEqualTypeOf<AMQPCoder>()
   expectTypeOf<R["custom"]>().toEqualTypeOf<AMQPCoder>()
+})
+
+// --- AMQPSession.connect() inference ---
+//
+// Regression guard against the static-connect overloads collapsing into a
+// single generic signature (see #210 / PR #227). We need to keep parser
+// type inference working through `parsers?: ParserRegistry<P>` on the impl,
+// since the old "parsers required" overload no longer exists.
+//
+// These are type-only probes: the functions are never invoked at runtime,
+// they only exist so TypeScript can type-check the call and we can extract
+// the resolved session type via `Awaited<ReturnType<typeof probe>>`. No
+// real broker connection happens.
+
+type SampleParsers = {
+  "text/plain": AMQPParser<string, string>
+  "application/json": AMQPParser<JsonSerializable, unknown>
+}
+declare const sampleParsers: SampleParsers
+
+// Type-only probes. Bodies never run — their job is to give TS a concrete
+// `connect()` call site so we can extract the inferred return type via
+// `Awaited<ReturnType<typeof probe>>`. Eslint flags them as unused since
+// they're only referenced at the type level; suppress per-line to keep
+// the noise local.
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+function probeNoOpts() {
+  return AMQPSession.connect("amqp://127.0.0.1")
+}
+function probeNoParsers() {
+  return AMQPSession.connect("amqp://127.0.0.1", { reconnectInterval: 500 })
+}
+function probeWithParsers() {
+  return AMQPSession.connect("amqp://127.0.0.1", { parsers: sampleParsers })
+}
+function probeWithDefaultContentType() {
+  return AMQPSession.connect("amqp://127.0.0.1", { parsers: sampleParsers, defaultContentType: "text/plain" })
+}
+/* eslint-enable @typescript-eslint/no-unused-vars */
+
+test("AMQPSession.connect() with no options returns AMQPSession<{}, {}, never, never>", () => {
+  expectTypeOf<Awaited<ReturnType<typeof probeNoOpts>>>().toEqualTypeOf<AMQPSession<{}, {}, never, never>>()
+})
+
+test("AMQPSession.connect() with options but no parsers returns AMQPSession<{}, {}, never, never>", () => {
+  expectTypeOf<Awaited<ReturnType<typeof probeNoParsers>>>().toEqualTypeOf<AMQPSession<{}, {}, never, never>>()
+})
+
+test("AMQPSession.connect() infers P from parsers field", () => {
+  expectTypeOf<Awaited<ReturnType<typeof probeWithParsers>>>().toEqualTypeOf<
+    AMQPSession<SampleParsers, {}, never, never>
+  >()
+})
+
+test("AMQPSession.connect() narrows KP via defaultContentType", () => {
+  expectTypeOf<Awaited<ReturnType<typeof probeWithDefaultContentType>>>().toEqualTypeOf<
+    AMQPSession<SampleParsers, {}, "text/plain", never>
+  >()
 })


### PR DESCRIPTION
## Background

Dogfooding `AMQPSession` for a service that needs an anonymous, exclusive, auto-delete queue bound to a fanout exchange (#210) ran into a recurring shape: declare a server-named queue, bind it, subscribe, and have all of that re-established after every reconnect. The natural place to put that wiring was the existing `onconnect` callback — but it didn't actually work for the initial connect, because `onconnect` fires *inside* `AMQPSession.connect()` before the caller's `const session = await ...` assignment completes. The closure saw `undefined` on the very first call and only started working from the first reconnect onward.

## Summary

- **`onconnect` receives the session as its argument.** Same instance on the initial connect and every reconnect; closures no longer need to reach an outer `session` variable that isn't bound yet.
- **Signature: `onconnect?(session: AMQPSession<P, C, KP, KC>): void`.** Full parser-typed inference preserved by collapsing the parser-required and non-generic `static connect` overloads into one generic signature with defaults — `parsers?: ParserRegistry<P>` still drives inference whether parsers are provided or not.
- **Fire-and-forget semantics.** If your handler does async setup the rest of your code depends on, drive it yourself after `connect()` resolves and reuse the function inside `onconnect` for reconnects:
  ```ts
  const session = await AMQPSession.connect(url, { onconnect: setup })
  await setup(session)   // initial run, explicit
  ```

## Test plan

- [x] `onconnect receives the session — usable on initial connect before AMQPSession.connect() returns` — declares a server-named queue inside `onconnect`, drops the socket, asserts the second declare runs and produces a different broker-assigned name. Synchronization via explicit promises, no `setTimeout` sleeps.
- [x] 4 type-only probes in `test/type-safety.ts` covering parser inference on `AMQPSession.connect()` (defaults, no-parsers, parsers, defaultContentType) — never-called functions whose return types TS extracts, so no broker dependency.
- [x] All 75 `test/amqp-session.ts` tests and 40 `test/type-safety.ts` tests pass.
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` clean.