### PR TITLE
Session: connection tuning, blocked/unblocked, mandatory/onreturn

### DIFF
--- a/src/amqp-base-client.ts
+++ b/src/amqp-base-client.ts
@@ -54,6 +54,18 @@ export abstract class AMQPBaseClient {
   ondisconnect?: (error?: Error) => void
 
   /**
+   * Callback when the server blocks publishing on this connection
+   * (typically due to a resource alarm — memory or disk).
+   * @param reason - The broker-supplied reason string
+   */
+  onblocked?: (reason: string) => void
+
+  /**
+   * Callback when the server lifts a previous block on this connection.
+   */
+  onunblocked?: () => void
+
+  /**
    * @param name - name of the connection, set in client properties
    * @param platform - used in client properties
    * @param logger - optional logger instance, defaults to undefined (no logging)
@@ -366,11 +378,13 @@ export abstract class AMQPBaseClient {
                   i += len
                   this.logger?.warn("AMQP connection blocked:", reason)
                   this.blocked = reason
+                  this.onblocked?.(reason)
                   break
                 }
                 case AMQPFrame.ConnectionMethod.UNBLOCKED: {
                   this.logger?.info("AMQP connection unblocked")
                   delete this.blocked
+                  this.onunblocked?.()
                   break
                 }
                 case AMQPFrame.ConnectionMethod.UPDATE_SECRET_OK: {

--- a/src/amqp-exchange.ts
+++ b/src/amqp-exchange.ts
@@ -12,8 +12,9 @@ export type ExchangePublishOptions<O extends string = string> = Omit<AMQPPropert
   confirm?: boolean
   /**
    * Ask the broker to return the message if it can't be routed to a queue.
-   * Returned messages are delivered to the session-level `onreturn` handler.
-   * Defaults to `false`.
+   * Returned messages are delivered to the session-level `onreturn` handler
+   * when one is configured; otherwise the default channel handler just
+   * logs them. Defaults to `false`.
    */
   mandatory?: boolean
   contentType?: O

--- a/src/amqp-exchange.ts
+++ b/src/amqp-exchange.ts
@@ -10,6 +10,12 @@ export type ExchangePublishOptions<O extends string = string> = Omit<AMQPPropert
   routingKey?: string
   /** Wait for broker confirmation. Defaults to `true`. */
   confirm?: boolean
+  /**
+   * Ask the broker to return the message if it can't be routed to a queue.
+   * Returned messages are delivered to the session-level `onreturn` handler.
+   * Defaults to `false`.
+   */
+  mandatory?: boolean
   contentType?: O
 }
 
@@ -53,7 +59,7 @@ export class AMQPExchange<
     body: ResolveBody<P, O>,
     options: ExchangePublishOptions<O> = {},
   ): Promise<AMQPExchange<P, C, KP, KC>> {
-    const { confirm = true, routingKey = "", ...properties } = options
+    const { confirm = true, routingKey = "", mandatory = false, ...properties } = options
     const defaults: { contentType?: string; contentEncoding?: string } = {}
     if (this.session.defaultContentType) defaults.contentType = this.session.defaultContentType
     if (this.session.defaultContentEncoding) defaults.contentEncoding = this.session.defaultContentEncoding
@@ -67,10 +73,10 @@ export class AMQPExchange<
     if (encoded.properties.deliveryMode === undefined) encoded.properties.deliveryMode = 2
     if (confirm) {
       const ch = await this.session.getConfirmChannel()
-      await ch.basicPublish(this.name, routingKey, encoded.body, encoded.properties)
+      await ch.basicPublish(this.name, routingKey, encoded.body, encoded.properties, mandatory)
     } else {
       await this.session.withOpsChannel(async (ch) => {
-        await ch.basicPublish(this.name, routingKey, encoded.body, encoded.properties)
+        await ch.basicPublish(this.name, routingKey, encoded.body, encoded.properties, mandatory)
       })
     }
     return this

--- a/src/amqp-mockable.ts
+++ b/src/amqp-mockable.ts
@@ -34,7 +34,7 @@ export interface AMQPSubscriptionLike {
 /** Minimum surface a mock queue handle must expose. */
 export interface AMQPQueueLike {
   readonly name: string
-  publish(body: unknown, options?: AMQPProperties & { confirm?: boolean }): Promise<unknown>
+  publish(body: unknown, options?: AMQPProperties & { confirm?: boolean; mandatory?: boolean }): Promise<unknown>
   subscribe(
     params: QueueSubscribeParams,
     callback: (msg: AMQPMessage) => void | Promise<void>,
@@ -46,7 +46,10 @@ export interface AMQPQueueLike {
 
 /** Minimum surface a mock exchange handle must expose. */
 export interface AMQPExchangeLike {
-  publish(body: unknown, options?: AMQPProperties & { routingKey?: string; confirm?: boolean }): Promise<unknown>
+  publish(
+    body: unknown,
+    options?: AMQPProperties & { routingKey?: string; confirm?: boolean; mandatory?: boolean },
+  ): Promise<unknown>
 }
 
 /** Minimum surface a mock session must expose. */

--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -30,8 +30,9 @@ export type QueuePublishOptions<T> = Omit<AMQPProperties, "contentType"> & {
   confirm?: boolean
   /**
    * Ask the broker to return the message if it can't be routed to a queue.
-   * Returned messages are delivered to the session-level `onreturn` handler.
-   * Defaults to `false`.
+   * Returned messages are delivered to the session-level `onreturn` handler
+   * when one is configured; otherwise the default channel handler just
+   * logs them. Defaults to `false`.
    */
   mandatory?: boolean
   contentType?: T

--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -28,6 +28,12 @@ export type QueueSubscribeParams = ConsumeParams & {
 export type QueuePublishOptions<T> = Omit<AMQPProperties, "contentType"> & {
   /** Wait for broker confirmation. Defaults to `true`. */
   confirm?: boolean
+  /**
+   * Ask the broker to return the message if it can't be routed to a queue.
+   * Returned messages are delivered to the session-level `onreturn` handler.
+   * Defaults to `false`.
+   */
+  mandatory?: boolean
   contentType?: T
 }
 
@@ -73,7 +79,7 @@ export class AMQPQueue<
     body: ResolveBody<P, O>,
     options: QueuePublishOptions<O> = {},
   ): Promise<AMQPQueue<P, C, KP, KC>> {
-    const { confirm = true, ...properties } = options
+    const { confirm = true, mandatory = false, ...properties } = options
     const defaults: { contentType?: string; contentEncoding?: string } = {}
     if (this.session.defaultContentType) defaults.contentType = this.session.defaultContentType
     if (this.session.defaultContentEncoding) defaults.contentEncoding = this.session.defaultContentEncoding
@@ -87,10 +93,10 @@ export class AMQPQueue<
     if (encoded.properties.deliveryMode === undefined) encoded.properties.deliveryMode = 2
     if (confirm) {
       const ch = await this.session.getConfirmChannel()
-      await ch.basicPublish("", this.name, encoded.body, encoded.properties)
+      await ch.basicPublish("", this.name, encoded.body, encoded.properties, mandatory)
     } else {
       await this.session.withOpsChannel(async (ch) => {
-        await ch.basicPublish("", this.name, encoded.body, encoded.properties)
+        await ch.basicPublish("", this.name, encoded.body, encoded.properties, mandatory)
       })
     }
     return this

--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -23,6 +23,7 @@ export type ExchangeOptions = ExchangeParams & {
   /** Exchange arguments table (e.g. `{ "x-delayed-type": "direct" }`). */
   arguments?: Record<string, unknown>
 }
+import { decodeMessage } from "./amqp-codec-registry.js"
 import type { ParserMap, CoderMap, ParserRegistry, CoderRegistry } from "./amqp-codec-registry.js"
 import type { AMQPProperties } from "./amqp-properties.js"
 import type { ResolveBody } from "./amqp-publisher.js"
@@ -313,10 +314,25 @@ export class AMQPSession<
 
   // Forward returned (unroutable mandatory) messages from a channel to the
   // session-level onreturn handler so callers register a single hook
-  // regardless of which channel published.
+  // regardless of which channel published. Decoded through the session's
+  // parsers/coders so the body shape matches what publish() accepted.
   private wireReturnHandler(ch: AMQPChannel): void {
     if (!this.onreturn) return
-    ch.onReturn = (msg) => this.onreturn?.(msg as AMQPMessage<P>)
+    ch.onReturn = (msg) => {
+      const handler = this.onreturn
+      if (!handler) return
+      void (async () => {
+        try {
+          if (this.parsers || this.coders) {
+            await decodeMessage(msg, this.parsers ?? {}, this.coders ?? {})
+          }
+          handler(msg as AMQPMessage<P>)
+        } catch (err) {
+          const error = err instanceof Error ? err : new Error(String(err))
+          this.client.logger?.warn(`${this.logTag()}: onreturn handler failed:`, error.message)
+        }
+      })()
+    }
   }
 
   // Serializes operations on the shared ops channel. AMQP channel-level

--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -71,6 +71,26 @@ export interface AMQPSessionOptions<
    */
   vhost?: string
   /**
+   * Connection name, shown in the RabbitMQ management UI. Overrides any
+   * `?name=` in the URL.
+   */
+  name?: string
+  /**
+   * Heartbeat interval in seconds (0 disables). Overrides any `?heartbeat=` in
+   * the URL.
+   */
+  heartbeat?: number
+  /**
+   * Max AMQP frame size in bytes (minimum 8192). Overrides any `?frameMax=` in
+   * the URL.
+   */
+  frameMax?: number
+  /**
+   * Max channels the session may open on this connection (0 = unlimited).
+   * Overrides any `?channelMax=` in the URL.
+   */
+  channelMax?: number
+  /**
    * Fires after a successful (re)connection — both the initial connect and
    * every reconnect after consumer recovery completes. Registering here
    * rather than after `connect()` resolves means a single handler covers
@@ -95,6 +115,21 @@ export interface AMQPSessionOptions<
   ondisconnect?: (error?: Error) => void
   /** Fires when max reconnect retries are exhausted. */
   onfailed?: (error?: Error) => void
+  /**
+   * Fires when the broker blocks the connection from publishing — usually
+   * triggered by a resource alarm (memory or disk) on the server. Subsequent
+   * publishes reject with `Connection blocked by server` until the broker
+   * unblocks. Use this to apply backpressure upstream.
+   */
+  onblocked?: (reason: string) => void
+  /** Fires when the broker lifts a previous block on the connection. */
+  onunblocked?: () => void
+  /**
+   * Fires when a `mandatory: true` publish is returned by the broker because
+   * it had no route to a queue. The session wires this onto every channel it
+   * opens for publishing, so a single handler covers all session publishes.
+   */
+  onreturn?: (msg: AMQPMessage<P>) => void
 }
 
 /**
@@ -116,6 +151,7 @@ export class AMQPSession<
   private readonly onconnect?: (session: AMQPSession<P, C, KP, KC>) => void
   private readonly ondisconnect?: (error?: Error) => void
   private readonly onfailed?: (error?: Error) => void
+  private readonly onreturn?: (msg: AMQPMessage<P>) => void
 
   private readonly client: AMQPBaseClient
 
@@ -169,6 +205,9 @@ export class AMQPSession<
     if (options?.onconnect) this.onconnect = options.onconnect
     if (options?.ondisconnect) this.ondisconnect = options.ondisconnect
     if (options?.onfailed) this.onfailed = options.onfailed
+    if (options?.onreturn) this.onreturn = options.onreturn
+    if (options?.onblocked) this.client.onblocked = options.onblocked
+    if (options?.onunblocked) this.client.onunblocked = options.onunblocked
     this.options = {
       reconnectInterval: options?.reconnectInterval ?? 1000,
       maxReconnectInterval: options?.maxReconnectInterval ?? 30000,
@@ -212,7 +251,10 @@ export class AMQPSession<
       const vhost = options?.vhost ?? "/"
       const username = decodeURIComponent(u.username) || "guest"
       const password = decodeURIComponent(u.password) || "guest"
-      const name = u.searchParams.get("name") ?? undefined
+      const name = options?.name ?? u.searchParams.get("name") ?? undefined
+      const heartbeat = options?.heartbeat ?? numericParam(u.searchParams.get("heartbeat"))
+      const frameMax = options?.frameMax ?? numericParam(u.searchParams.get("frameMax"))
+      const channelMax = options?.channelMax ?? numericParam(u.searchParams.get("channelMax"))
       const wsUrl = `${u.protocol}//${u.host}${u.pathname}${u.search}`
       const init: ConstructorParameters<typeof AMQPWebSocketClient>[0] = {
         url: wsUrl,
@@ -222,10 +264,25 @@ export class AMQPSession<
         logger: options?.logger ?? null,
       }
       if (name) init.name = name
+      if (heartbeat !== undefined) init.heartbeat = heartbeat
+      if (frameMax !== undefined) init.frameMax = frameMax
+      if (channelMax !== undefined) init.channelMax = channelMax
       client = new AMQPWebSocketClient(init)
     } else {
       const { AMQPClient } = await import("./amqp-socket-client.js")
-      client = new AMQPClient(url, options?.tlsOptions, options?.logger)
+      // AMQPClient reads name/heartbeat/frameMax/channelMax from URL query
+      // params, so route options through the URL rather than touching the
+      // low-level constructor signature.
+      const overrides: Record<string, string | undefined> = {
+        name: options?.name,
+        heartbeat: options?.heartbeat?.toString(),
+        frameMax: options?.frameMax?.toString(),
+        channelMax: options?.channelMax?.toString(),
+      }
+      for (const [key, val] of Object.entries(overrides)) {
+        if (val !== undefined) u.searchParams.set(key, val)
+      }
+      client = new AMQPClient(u.toString(), options?.tlsOptions, options?.logger)
     }
     await client.connect()
     const session = new AMQPSession(client, options)
@@ -243,6 +300,7 @@ export class AMQPSession<
     if (this.opsChannel && !this.opsChannel.closed) return Promise.resolve(this.opsChannel)
     if (this.opsChannelPromise) return this.opsChannelPromise
     this.opsChannelPromise = this.client.channel().then((ch) => {
+      this.wireReturnHandler(ch)
       this.opsChannel = ch
       this.opsChannelPromise = null
       return ch
@@ -251,6 +309,14 @@ export class AMQPSession<
       this.opsChannelPromise = null
     })
     return this.opsChannelPromise
+  }
+
+  // Forward returned (unroutable mandatory) messages from a channel to the
+  // session-level onreturn handler so callers register a single hook
+  // regardless of which channel published.
+  private wireReturnHandler(ch: AMQPChannel): void {
+    if (!this.onreturn) return
+    ch.onReturn = (msg) => this.onreturn?.(msg as AMQPMessage<P>)
   }
 
   // Serializes operations on the shared ops channel. AMQP channel-level
@@ -291,6 +357,7 @@ export class AMQPSession<
     if (this.confirmChannelPromise) return this.confirmChannelPromise
     this.confirmChannelPromise = this.client.channel().then(async (ch) => {
       await ch.confirmSelect()
+      this.wireReturnHandler(ch)
       this.confirmChannel = ch
       this.confirmChannelPromise = null
       return ch
@@ -551,4 +618,10 @@ export class AMQPSession<
       }
     }
   }
+}
+
+function numericParam(value: string | null): number | undefined {
+  if (value === null) return undefined
+  const n = Number(value)
+  return Number.isFinite(n) ? n : undefined
 }

--- a/src/amqp-websocket-client.ts
+++ b/src/amqp-websocket-client.ts
@@ -14,6 +14,7 @@ export interface AMQPWebSocketInit {
   name?: string
   frameMax?: number
   heartbeat?: number
+  channelMax?: number
   logger?: Logger | null
 }
 
@@ -53,6 +54,7 @@ export class AMQPWebSocketClient extends AMQPBaseClient {
     heartbeat = 0,
     logger?: Logger | null,
   ) {
+    let channelMax = 0
     if (typeof url === "object") {
       vhost = url.vhost ?? vhost
       username = url.username ?? username
@@ -60,10 +62,11 @@ export class AMQPWebSocketClient extends AMQPBaseClient {
       name = url.name ?? name
       frameMax = url.frameMax ?? frameMax
       heartbeat = url.heartbeat ?? heartbeat
+      channelMax = url.channelMax ?? channelMax
       logger = url.logger ?? logger
       url = url.url
     }
-    super(vhost, username, password, name, AMQPWebSocketClient.platform(), frameMax, heartbeat, 0, logger)
+    super(vhost, username, password, name, AMQPWebSocketClient.platform(), frameMax, heartbeat, channelMax, logger)
     this.url = url
     this.frameBuffer = new Uint8Array(frameMax)
   }

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -1414,6 +1414,29 @@ test("mandatory publish that routes does not trigger onreturn", async () => {
   }
 })
 
+test("returned messages are decoded via session parsers before onreturn", async () => {
+  let returned!: (msg: AMQPMessage) => void
+  const got = new Promise<AMQPMessage>((resolve) => {
+    returned = resolve
+  })
+  const session = await AMQPSession.connect("amqp://127.0.0.1", {
+    parsers: builtinParsers,
+    defaultContentType: "application/json",
+    onreturn: (msg) => returned(msg),
+  })
+  try {
+    const q = new AMQPQueue(session, "does-not-exist-" + Math.random())
+    await q.publish({ hello: "world" }, { mandatory: true, confirm: false })
+    const msg = await Promise.race([
+      got,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("onreturn never fired")), 2000)),
+    ])
+    expect(msg.body).toEqual({ hello: "world" })
+  } finally {
+    await session.stop()
+  }
+})
+
 test("onblocked / onunblocked can be wired through options", async () => {
   // Triggering connection.blocked requires hitting a broker resource alarm,
   // which isn't safe to do in a shared test broker. Instead, verify the

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -1337,3 +1337,98 @@ test("consumeOne rejects when the connection drops before delivery", () =>
     },
     { reconnectInterval: 50, maxRetries: 1 },
   ))
+
+test("name option sets connection name (overrides URL query)", async () => {
+  const session = await AMQPSession.connect("amqp://127.0.0.1?name=from-url", { name: "from-option" })
+  try {
+    expect(testClient(session).name).toBe("from-option")
+  } finally {
+    await session.stop()
+  }
+})
+
+test("heartbeat option negotiates with broker", async () => {
+  const session = await AMQPSession.connect("amqp://127.0.0.1", { heartbeat: 30 })
+  try {
+    // The broker may negotiate down, but 30 is well within RabbitMQ defaults.
+    expect(testClient(session).heartbeat).toBe(30)
+  } finally {
+    await session.stop()
+  }
+})
+
+test("frameMax option negotiates with broker", async () => {
+  const session = await AMQPSession.connect("amqp://127.0.0.1", { frameMax: 16384 })
+  try {
+    expect(testClient(session).frameMax).toBe(16384)
+  } finally {
+    await session.stop()
+  }
+})
+
+test("channelMax option negotiates with broker", async () => {
+  const session = await AMQPSession.connect("amqp://127.0.0.1", { channelMax: 64 })
+  try {
+    expect(testClient(session).channelMax).toBe(64)
+  } finally {
+    await session.stop()
+  }
+})
+
+test("mandatory publish to unroutable address triggers onreturn", async () => {
+  let returned!: (msg: AMQPMessage) => void
+  const got = new Promise<AMQPMessage>((resolve) => {
+    returned = resolve
+  })
+  const session = await AMQPSession.connect("amqp://127.0.0.1", {
+    onreturn: (msg) => returned(msg),
+  })
+  try {
+    // Default exchange routes by queue name. No queue with this name exists, so
+    // mandatory:true makes the broker return the message.
+    const q = new AMQPQueue(session, "does-not-exist-" + Math.random())
+    await q.publish("hello", { mandatory: true, confirm: false })
+    const msg = await Promise.race([
+      got,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("onreturn never fired")), 2000)),
+    ])
+    expect(msg.routingKey).toBe(q.name)
+  } finally {
+    await session.stop()
+  }
+})
+
+test("mandatory publish that routes does not trigger onreturn", async () => {
+  const onreturn = vi.fn()
+  const session = await AMQPSession.connect("amqp://127.0.0.1", { onreturn })
+  try {
+    const q = await session.queue("test-mandatory-routes-" + Math.random(), {
+      durable: false,
+      autoDelete: true,
+    })
+    await q.publish("hello", { mandatory: true })
+    await new Promise((r) => setTimeout(r, 100))
+    expect(onreturn).not.toHaveBeenCalled()
+  } finally {
+    await session.stop()
+  }
+})
+
+test("onblocked / onunblocked can be wired through options", async () => {
+  // Triggering connection.blocked requires hitting a broker resource alarm,
+  // which isn't safe to do in a shared test broker. Instead, verify the
+  // session forwards the handlers onto the underlying client and simulate
+  // the frame handler firing them.
+  const onblocked = vi.fn()
+  const onunblocked = vi.fn()
+  const session = await AMQPSession.connect("amqp://127.0.0.1", { onblocked, onunblocked })
+  try {
+    const client = testClient(session)
+    client.onblocked?.("low on memory")
+    client.onunblocked?.()
+    expect(onblocked).toHaveBeenCalledWith("low on memory")
+    expect(onunblocked).toHaveBeenCalledTimes(1)
+  } finally {
+    await session.stop()
+  }
+})


### PR DESCRIPTION
## Background

A gap report on the new high-level `AMQPSession` API vs. the low-level `AMQPChannel` it wraps surfaced a handful of things worth covering before the v2 cut. The rest (`txSelect`, `basicFlow`, `basicRecover`, `prefetchSize`, channel-global prefetch) are deprecated, broker-ignored, or already covered by other Session mechanisms (publisher confirms, reconnect-driven recovery).

## Summary

- **Connection tuning** on `AMQPSessionOptions`: `name`, `heartbeat`, `frameMax`, `channelMax`. Useful for ops (connection name shows up in the RabbitMQ management UI) and for tuning heartbeats on flaky networks. URL query params still work; options win when both are set.
- **`onblocked` / `onunblocked`** forwarded from the broker's `connection.blocked` / `connection.unblocked` frames. Without these, publishes start rejecting with `Connection blocked by server` and the caller has no way to back off until the alarm clears.
- **`mandatory: true`** on `publish()` and a session-level **`onreturn`** handler. Wired onto both the ops channel and the confirm channel so a single handler covers every session publish.

## Notes

- `AMQPClient` (TCP) already accepts these tunables via URL query params, so the Session routes options through the URL rather than changing the low-level constructor signature.
- `AMQPWebSocketInit` gained a `channelMax` field for symmetry.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx vitest run test/amqp-session.ts test/amqp-codec-registry.ts test/type-safety.ts` (150 passed)
- [x] New tests: name/heartbeat/frameMax/channelMax negotiation, mandatory-unroutable triggers onreturn, mandatory-routed does not, onblocked/onunblocked forwarded
- [ ] Verify downstream consumers keep working against the new Session

`test/test.ts` (the pre-v2 low-level suite) OOMs on this branch and on `main`, so it's not exercised here.