### PR TITLE
session: don't log expected managed-channel closes as connection errors

### DIFF
--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -302,6 +302,7 @@ export class AMQPSession<
     if (this.opsChannelPromise) return this.opsChannelPromise
     this.opsChannelPromise = this.client.channel().then((ch) => {
       this.wireReturnHandler(ch)
+      this.wireManagedChannelErrorHandler(ch)
       this.opsChannel = ch
       this.opsChannelPromise = null
       return ch
@@ -332,6 +333,15 @@ export class AMQPSession<
           this.client.logger?.warn(`${this.logTag()}: onreturn handler failed:`, error.message)
         }
       })()
+    }
+  }
+
+  // Ops/confirm channels reopen on next use, so an expected close (e.g. a
+  // passive declare of a missing queue) shouldn't hit the connection error
+  // log. The awaiting RPC still rejects via setClosed. Matches amqp-client.rb.
+  private wireManagedChannelErrorHandler(ch: AMQPChannel): void {
+    ch.onerror = (reason) => {
+      this.client.logger?.debug(`${this.logTag()}: channel ${ch.id} closed (${reason}); will reopen on next use`)
     }
   }
 
@@ -374,6 +384,7 @@ export class AMQPSession<
     this.confirmChannelPromise = this.client.channel().then(async (ch) => {
       await ch.confirmSelect()
       this.wireReturnHandler(ch)
+      this.wireManagedChannelErrorHandler(ch)
       this.confirmChannel = ch
       this.confirmChannelPromise = null
       return ch

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -1216,6 +1216,27 @@ test("ops channel: passive NOT_FOUND doesn't disrupt concurrent declares", () =>
     expect(results[1]?.status).toBe("fulfilled")
   }))
 
+test("ops channel: passive NOT_FOUND doesn't log a connection error and recovers", async () => {
+  // Passive declare of a missing queue closes the ops channel. The miss must
+  // not log a connection error, and the channel must recover.
+  const error = vi.fn()
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error }
+  await withSession(
+    async (session) => {
+      await expect(session.queue("nope-" + Math.random(), { passive: true })).rejects.toThrow(/NOT[_-]?FOUND/i)
+      expect(error).not.toHaveBeenCalled()
+
+      // Ops channel recovered: a follow-up declare on the shared channel works.
+      const okName = "test-after-passive-miss-" + Math.random()
+      const q = await session.queue(okName, { durable: false, autoDelete: true })
+      expect(q).toBeInstanceOf(AMQPQueue)
+      await q.delete()
+      expect(error).not.toHaveBeenCalled()
+    },
+    { logger },
+  )
+})
+
 test("ops channel: PRECONDITION_FAILED on mismatched declare doesn't disrupt siblings", () =>
   withSession(async (owner) => {
     // Declare the queue from one session, then from a second session declare


### PR DESCRIPTION
## Background

`session.queue(name, { passive: true })` runs on the shared ops channel. A passive declare of a missing queue closes the channel with NOT_FOUND, which is expected — the caller uses it to test for existence. The ops channel recovers on next use, but the default channel error handler forwards the close to the connection-level `onerror`, which logs `amqp-client connection closed`. That's misleading (the connection is fine) and noisy for callers that probe for queues that often don't exist.

`amqp-client.rb` doesn't do this — it recreates the channel on close and never surfaces a channel close as a connection error.

## Summary

Give the session-managed ops and confirm channels a quiet error handler that debug-logs the recoverable close instead of routing it to the connection error log. The awaiting RPC/publish still rejects via `setClosed`, and the channel reopens on next use. No API change.

Test: a passive declare of a missing queue rejects with NOT_FOUND, doesn't invoke the connection error logger, and the ops channel recovers.