### PR TITLE
session: catch no-ack consumer callback errors

### DIFF
--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -9,6 +9,7 @@ import type { AMQPExchange } from "./amqp-exchange.js"
 import type { ResolveBody } from "./amqp-publisher.js"
 import { serializeAndEncode, decodeMessage } from "./amqp-codec-registry.js"
 import type { ParserMap, CoderMap } from "./amqp-codec-registry.js"
+import type { Logger } from "./types.js"
 
 /**
  * Options for {@link AMQPQueue#subscribe}.
@@ -134,7 +135,14 @@ export class AMQPQueue<
 
     const parsers = this.session.parsers
     const coders = this.session.coders
-    const wrappedCallback = wrapCallbackWithAutoDecodeAndAck(callback, { parsers, coders, autoAck, requeueOnNack })
+    const logger = this.session.logger
+    const wrappedCallback = wrapCallbackWithAutoDecodeAndAck(callback, {
+      parsers,
+      coders,
+      autoAck,
+      requeueOnNack,
+      logger,
+    })
     const def: ConsumerDefinition = {
       queueName: this.name,
       consumeParams,
@@ -355,13 +363,20 @@ function wrapCallbackWithAutoDecodeAndAck<P extends ParserMap>(
     coders: CoderMap | undefined
     autoAck: boolean
     requeueOnNack: boolean
+    logger: Logger | null | undefined
   },
 ): InternalCallback | undefined {
   if (!callback) return undefined
   if (!opts.autoAck) {
     return async (msg: AMQPMessage) => {
-      if (opts.parsers || opts.coders) await decodeMessage(msg, opts.parsers ?? {}, opts.coders ?? {})
-      await callback(msg as AMQPMessage<P>)
+      // Nobody awaits this delivery, so an uncaught decode or callback error
+      // becomes an unhandledRejection. No-ack can't nack, so just log.
+      try {
+        if (opts.parsers || opts.coders) await decodeMessage(msg, opts.parsers ?? {}, opts.coders ?? {})
+        await callback(msg as AMQPMessage<P>)
+      } catch (err) {
+        opts.logger?.error("Consumer callback error", err)
+      }
     }
   }
   return async (msg: AMQPMessage) => {

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -51,6 +51,51 @@ test("session.subscribe delivers messages via callback", () =>
     await sub.cancel()
   }))
 
+test("subscribe: a throwing no-ack callback is logged, not an unhandled rejection", async () => {
+  const error = vi.fn()
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error }
+  await withSession(
+    async (session) => {
+      const q = await session.queue("test-throwing-cb-" + Math.random(), { durable: false, autoDelete: true })
+      const sub = await q.subscribe({ noAck: true }, () => {
+        throw new Error("boom")
+      })
+
+      await q.publish("test", { confirm: false })
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      expect(error).toHaveBeenCalled()
+      await sub.cancel()
+    },
+    { logger },
+  )
+})
+
+test("subscribe: a decode failure is logged, not an unhandled rejection", async () => {
+  const error = vi.fn()
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error }
+  await withSession(
+    async (session) => {
+      const q = await session.queue("test-bad-decode-" + Math.random(), { durable: false, autoDelete: true })
+      let delivered = false
+      const sub = await q.subscribe({ noAck: true }, () => {
+        delivered = true
+      })
+
+      // Publish raw so the body bypasses serialization: claims JSON, isn't.
+      const ch = await testClient(session).channel()
+      await ch.basicPublish("", q.name, "not json {", { contentType: "application/json" })
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      expect(error).toHaveBeenCalled()
+      expect(delivered).toBe(false)
+      await ch.close()
+      await sub.cancel()
+    },
+    { logger, parsers: builtinParsers },
+  )
+})
+
 test("session.subscribe accepts a broker-named queue", () =>
   withSession(async (session) => {
     const q = await session.queue("", { durable: false, autoDelete: true })


### PR DESCRIPTION
## Background

`wrapCallbackWithAutoDecodeAndAck` has two branches:

- **auto-ack** wraps decode + callback in `try/catch` so it can `nack` on error.
- **no-ack** does neither — it just `await`s decode, then the callback.

`AMQPChannel.deliver` invokes the consumer callback inside a `queueMicrotask` and does not await the returned promise. So in the no-ack case, a throwing handler — or a decode failure, which happens inside the library *before* the user callback runs (a poison message whose content-type/encoding has no matching parser/coder) — rejects a promise nobody awaits. That surfaces as an `unhandledRejection`, which is fatal for any process with a strict `unhandledRejection` handler.

The decode case is the worst part: it throws before the user's callback, so the consuming app has no seam to catch it. A consumer that subscribes with `noAck: true` and relies on session parsers/coders to decode bodies can be taken down by a single message it can't decode.

## What changed

Mirror the auto-ack branch's error handling in the no-ack branch. With no-ack there's nothing to nack, so log the error via the session logger and move on.

The fix lives in the session callback wrapper rather than in `AMQPChannel.deliver`. A `deliver`-level catch covers every consumer type, but it adds a per-delivery microtask to the low-level `basicConsume` path and made `test/test.ts` › "can republish in consume block without race condition" fail ~5/6 with ECONNRESET (a timing-sensitive stress test). The wrapper is where the library already takes ownership of the user's callback (decoding for them, ack/nack for them), so it's the right place to own error handling too. The raw `basicConsume(..., cb)` path keeps its existing contract — the caller owns callback rejections.

## Tests

Two new cases in `test/amqp-session.ts`:
- a throwing no-ack callback is logged, not an unhandled rejection
- a decode failure (raw-published message claiming `application/json` that isn't) is logged, not an unhandled rejection

Both reproduce the crash before the change (unhandled rejection traced to `amqp-channel.ts` → `AMQPConsumer.onMessage`) and pass after. Full `test/amqp-session.ts` + `test/amqp-codec-registry.ts` green (124), `test/test.ts` matches baseline, typecheck/eslint/prettier clean.