### PR TITLE
Polish release docs: codecs in README, clean typedoc build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `AMQPCodecRegistry` — opt-in automatic encoding/decoding of message bodies by content-type ([#192](https://github.com/cloudamqp/amqp-client.js/pull/192))
   - Builtin codec constants for JSON, text, and raw bytes; register your own for other content-types
+  - `builtinParsers` (JSON, text) and `builtinCoders` (gzip, deflate) ship ready to spread into the registry; `BuiltinParsers` / `BuiltinCoders` describe their shape
+  - `defaultContentType` / `defaultContentEncoding` session options apply codecs to publishes that don't set them explicitly
   - Wired into `AMQPClient`, `AMQPSession`, `AMQPQueue`, `AMQPExchange`, `AMQPSubscription`, `AMQPRPCClient`, and `AMQPRPCServer`
   - `CodecMode` generic (`"plain" | "codec"`) threads through session, queue, exchange, RPC, and message types so the body type is inferred at compile time
   - `AMQPMessage<CodecMode>` exposes `msg.body` as `Uint8Array` in `"plain"` mode and the decoded value in `"codec"` mode

--- a/README.md
+++ b/README.md
@@ -62,6 +62,42 @@ await x.publish("user signed up", { routingKey: "events.user.created" })
 await session.stop()
 ```
 
+#### Automatic encoding/decoding (codecs)
+
+Opt in to a codec registry and the session serializes and deserializes message bodies for you based on `content-type` and `content-encoding`. Pass `builtinParsers` (JSON, text) and `builtinCoders` (gzip, deflate), and optionally set defaults so you don't repeat them on every publish:
+
+```javascript
+import { AMQPSession, builtinParsers, builtinCoders } from "@cloudamqp/amqp-client"
+
+const session = await AMQPSession.connect("amqp://localhost", {
+  parsers: builtinParsers,
+  coders: builtinCoders,
+  defaultContentType: "application/json", // applied when publish() doesn't set one
+  defaultContentEncoding: "gzip", // body is gzip-compressed on the wire
+})
+
+const q = await session.queue("jobs")
+
+// Object is serialized to JSON and gzip-compressed automatically
+await q.publish({ task: "resize", id: 42 })
+
+// On consume, msg.body is the decoded value — no JSON.parse, no decompression
+const sub = await q.subscribe(async (msg) => {
+  console.log(msg.body.task) // "resize"
+})
+```
+
+`msg.body` is `Uint8Array` when no codecs are configured and the decoded value when they are; the `CodecMode` generic infers this at compile time. Override per publish by passing `contentType` / `contentEncoding` in the options. Register your own codecs by merging with the built-ins:
+
+```javascript
+const session = await AMQPSession.connect("amqp://localhost", {
+  parsers: { ...builtinParsers, "text/csv": csvParser },
+  coders: { ...builtinCoders, lz4: lz4Coder },
+})
+```
+
+Decode failures surface as a plain `Error` (not `AMQPError`); in `subscribe()` they nack the message, honoring `requeueOnNack`.
+
 #### Reconnection options
 
 ```javascript

--- a/src/amqp-codec-registry.ts
+++ b/src/amqp-codec-registry.ts
@@ -20,7 +20,8 @@ export type JsonSerializable =
   | JsonSerializable[]
   | { [key: string]: JsonSerializable }
 
-type BuiltinParsers = {
+/** Shape of {@link builtinParsers}: `text/plain` and `application/json`. */
+export type BuiltinParsers = {
   "text/plain": AMQPParser<string, string>
   "application/json": AMQPParser<JsonSerializable, unknown>
 }
@@ -33,7 +34,8 @@ export type CoderMap = { [K: string]: AMQPCoder }
 /** Readonly view of a {@link CoderMap}. */
 export type CoderRegistry<T extends CoderMap> = { readonly [K in keyof T & string]: T[K] }
 
-type BuiltinCoders = { gzip: AMQPCoder; deflate: AMQPCoder }
+/** Shape of {@link builtinCoders}: `gzip` and `deflate`. */
+export type BuiltinCoders = { gzip: AMQPCoder; deflate: AMQPCoder }
 
 /** Handles serialization/deserialization based on content-type. */
 export interface AMQPParser<In = unknown, Out = unknown> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,8 @@ export type {
   CoderMap,
   ParserRegistry,
   CoderRegistry,
+  BuiltinParsers,
+  BuiltinCoders,
   InferParserInput,
   InferParserOutput,
   JsonSerializable,


### PR DESCRIPTION
## Background

We're getting ready to cut the next release (a major bump — it carries the breaking changes that move `AMQPQueue` to a session-only handle). Doing a pass over the release artifacts surfaced two gaps in how the new high-level API is presented.

The codec registry is one of the headline high-level features, but it had no example anywhere in the README — a reader landing on the docs would have no idea automatic JSON/gzip handling exists. The sibling Ruby client leads its high-level section with codec configuration, so the JS docs should pull it forward the same way.

Separately, `npm run docs` (typedoc, which runs on tag in CI) emitted two warnings because the public `builtinParsers` / `builtinCoders` constants referenced type aliases that weren't exported.

## Summary

- Export `BuiltinParsers` and `BuiltinCoders` from the package entry point. They back the public `builtinParsers` / `builtinCoders` consts; exporting them clears the two typedoc "referenced but not documented" warnings so the docs site builds clean.
- Add an "Automatic encoding/decoding (codecs)" subsection to the high-level API in the README: builtins, default content-type/encoding, registering custom codecs, and decode-error behavior.
- Two CHANGELOG bullets for the codec entry that were missing: the builtin consts/types and the `defaultContentType` / `defaultContentEncoding` session options.

## Verification

`npm run docs` (0 warnings), `typecheck`, `lint`, `format:check` all clean. Codec registry and type-safety tests pass.
