### PR TITLE
fix(release): trusted publishing + preserve changelog in tag message

### DIFF
--- a/scripts/release-tag.js
+++ b/scripts/release-tag.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import fs from "fs"
-import { execSync } from "child_process"
+import { execFileSync } from "child_process"
 
 function main() {
   // Read package.json to get current version
@@ -37,18 +37,17 @@ function main() {
 
   // Check if tag already exists
   try {
-    execSync(`git rev-parse ${tagName}`, { stdio: "pipe" })
+    execFileSync("git", ["rev-parse", tagName], { stdio: "pipe" })
     console.log(`⚠️  Tag ${tagName} already exists. Skipping tag creation.`)
     return
   } catch {
     // Tag doesn't exist, continue with creation
   }
 
-  // Escape backticks and other shell special characters in the content
-  const escapedContent = content.replace(/`/g, "\\`").replace(/\$/g, "\\$")
-
+  // Pass args directly to git (no shell) so changelog markup needs no escaping.
+  // --cleanup=verbatim keeps the Markdown "#" headers git would otherwise strip as comments.
   try {
-    execSync(`git tag -a ${tagName} -m ${JSON.stringify(escapedContent)}`, {
+    execFileSync("git", ["tag", "-a", "--cleanup=verbatim", tagName, "-m", content], {
       stdio: "inherit",
     })
     console.log(`✅ Created tag ${tagName} successfully`)


### PR DESCRIPTION
Cutting the v4.0.0 release surfaced two problems in the release plumbing, plus the publish itself failed on authentication. This bundles the fixes needed to make the release pipeline work end to end.

## Trusted publishing

The `npm publish` step authenticated with a long-lived `NPM_TOKEN` secret that was years old and no longer valid, so the publish 404'd. Rather than mint another long-lived token, switch to npm OIDC trusted publishing: the workflow already requests `id-token: write`, so npm can authenticate over OIDC with nothing stored to rotate or leak.

- Bump `actions/setup-node` to v6 and pin Node 24; upgrade npm before publishing, since trusted publishing needs npm >= 11.5.1.
- Drop the `NODE_AUTH_TOKEN` env from the publish step. The npm CLI detects the OIDC environment automatically.

One-time setup required on npmjs.com before this can publish: add a trusted publisher to the `@cloudamqp/amqp-client` package settings (organization `cloudamqp`, repository `amqp-client.js`, workflow filename `release.yml`, allowed action `npm publish`).

## Tag message

The `create-tag` step printed a wall of `/bin/sh: command not found` errors and produced an annotated tag with an empty message, instead of embedding that version's changelog section as designed.

`scripts/release-tag.js` assembled a shell command string and ran it through `/bin/sh -c`, so changelog markup (backticks, `$(...)`, parentheses, `${name}`) got interpreted by the shell despite ad-hoc escaping. A second, quieter bug: git's default tag-message cleanup strips lines starting with `#`, so even a clean message would lose every Markdown `##`/`###` header.

- Replace `execSync` with `execFileSync`, passing git its arguments as an array. No shell, so the changelog needs no escaping.
- Add `--cleanup=verbatim` so the Markdown headers survive.

Verified against the real 4.0.0 changelog: the tag message now matches it byte-for-byte, headers included, no shell errors. This only affects the local annotated tag; npm publish and the GitHub release pull notes from CHANGELOG.md directly.