### PR TITLE
ci(release): publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,18 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          node-version: "24"
           registry-url: https://registry.npmjs.org/
+      # Trusted Publishing (OIDC) needs npm >= 11.5.1; ensure it regardless of the bundled version
+      - run: npm install -g npm@latest
       - run: npm install
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - run: npm run build
+      # No NODE_AUTH_TOKEN: npm authenticates to the registry via OIDC trusted publishing
       - run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
         # create GitHub release
       - name: Extract release notes


### PR DESCRIPTION
Publishing v4.0.0 failed because the `npm publish` step authenticated with an `NPM_TOKEN` secret that was years old and no longer valid (a 404 on publish, npm's signal for a bad credential on a scoped package). A replacement publish token then hit `EOTP` because it still required a one-time password in CI.

Rather than mint another long-lived token, switch to npm OIDC trusted publishing. The workflow already requests `id-token: write`, so npm can authenticate over OIDC with nothing stored to rotate, expire, or leak.

## Changes

- Bump `actions/setup-node` to v6 and pin Node 24.
- Upgrade npm before publishing; trusted publishing requires npm >= 11.5.1.
- Drop the `NODE_AUTH_TOKEN` env from the publish step. The npm CLI detects the OIDC environment and authenticates automatically.

## Required one-time setup on npmjs.com

Before this can publish, add a trusted publisher to the `@cloudamqp/amqp-client` package settings:

- Organization or user: `cloudamqp`
- Repository: `amqp-client.js`
- Workflow filename: `release.yml`
- Allowed action: `npm publish`

Once merged and configured, re-tagging `v4.0.0` onto the merged commit triggers the release workflow and publishes via OIDC. The `NPM_TOKEN` secret can then be deleted.