### PR TITLE
AMQPSession: add beforeConnect hook

### DIFF
--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -92,6 +92,18 @@ export interface AMQPSessionOptions<
    */
   channelMax?: number
   /**
+   * Fires before every connection attempt — the initial connect and every
+   * reconnect, awaited before the underlying socket opens. Use it for setup
+   * the connection depends on, e.g. port-knocking (sparoid) to open the
+   * broker's firewall, or refreshing a short-lived credential.
+   *
+   * Awaited: a returned promise is resolved before the connect proceeds. If
+   * it throws, the connect attempt is skipped and the reconnect loop backs
+   * off and retries (the throw is treated like a failed connect), so a
+   * transient knock failure doesn't abort recovery.
+   */
+  beforeConnect?: () => void | Promise<void>
+  /**
    * Fires after a successful (re)connection — both the initial connect and
    * every reconnect after consumer recovery completes. Registering here
    * rather than after `connect()` resolves means a single handler covers
@@ -149,6 +161,7 @@ export class AMQPSession<
   KP extends keyof P & string = never,
   KC extends keyof C & string = never,
 > {
+  private readonly beforeConnect?: () => void | Promise<void>
   private readonly onconnect?: (session: AMQPSession<P, C, KP, KC>) => void
   private readonly ondisconnect?: (error?: Error) => void
   private readonly onfailed?: (error?: Error) => void
@@ -203,6 +216,7 @@ export class AMQPSession<
     if (options?.coders) this.coders = options.coders
     if (options?.defaultContentType) this.defaultContentType = options.defaultContentType
     if (options?.defaultContentEncoding) this.defaultContentEncoding = options.defaultContentEncoding
+    if (options?.beforeConnect) this.beforeConnect = options.beforeConnect
     if (options?.onconnect) this.onconnect = options.onconnect
     if (options?.ondisconnect) this.ondisconnect = options.ondisconnect
     if (options?.onfailed) this.onfailed = options.onfailed
@@ -285,6 +299,7 @@ export class AMQPSession<
       }
       client = new AMQPClient(u.toString(), options?.tlsOptions, options?.logger)
     }
+    await options?.beforeConnect?.()
     await client.connect()
     const session = new AMQPSession(client, options)
     client.logger?.info(`${session.logTag()}: connected`)
@@ -606,8 +621,11 @@ export class AMQPSession<
       await this.waitBeforeRetry(delay)
       if (this.stopped) continue // stop() was called during the wait
 
-      // Attempt to connect — retry on failure
+      // Attempt to connect — retry on failure. beforeConnect runs first so
+      // port-knocking / credential refresh happens ahead of every attempt; a
+      // throw here is treated like a failed connect so the loop backs off.
       try {
+        await this.beforeConnect?.()
         await this.client.connect()
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err))

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -299,6 +299,90 @@ test("onconnect fires after successful reconnection", async () => {
   expect(count).toBe(2)
 })
 
+test("beforeConnect fires before the initial connect", async () => {
+  const order: string[] = []
+  const beforeConnect = vi.fn(() => {
+    order.push("before")
+  })
+  const session = await AMQPSession.connect("amqp://127.0.0.1", {
+    beforeConnect,
+    onconnect: () => order.push("connected"),
+  })
+  try {
+    expect(beforeConnect).toHaveBeenCalledTimes(1)
+    expect(order).toEqual(["before", "connected"])
+  } finally {
+    await session.stop()
+  }
+})
+
+test("beforeConnect fires again before every reconnect", async () => {
+  let calls = 0
+  const reconnected = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("reconnect did not fire within 5s")), 5_000)
+    const session = AMQPSession.connect("amqp://127.0.0.1", {
+      reconnectInterval: 50,
+      maxRetries: 5,
+      beforeConnect: () => {
+        calls++
+      },
+      onconnect: () => {
+        // Second onconnect == reconnect completed; beforeConnect must have
+        // run ahead of it both times.
+        if (calls >= 2) {
+          clearTimeout(timeout)
+          resolve()
+        }
+      },
+    })
+    session.then((s) => (testClient(s) as AMQPClient).socket?.destroy()).catch(reject)
+  })
+  await reconnected
+  expect(calls).toBeGreaterThanOrEqual(2)
+})
+
+test("beforeConnect is awaited before connecting", async () => {
+  let resolved = false
+  const session = await AMQPSession.connect("amqp://127.0.0.1", {
+    beforeConnect: async () => {
+      await new Promise((r) => setTimeout(r, 50))
+      resolved = true
+    },
+  })
+  try {
+    // connect() only resolves after the async beforeConnect settled.
+    expect(resolved).toBe(true)
+  } finally {
+    await session.stop()
+  }
+})
+
+test("a throwing beforeConnect on reconnect backs off and retries instead of aborting", async () => {
+  let attempts = 0
+  const recovered = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("did not recover within 5s")), 5_000)
+    const session = AMQPSession.connect("amqp://127.0.0.1", {
+      reconnectInterval: 50,
+      maxRetries: 10,
+      beforeConnect: () => {
+        attempts++
+        // Fail the first reconnect's hook (attempt 2): the loop should
+        // back off and try again, not give up.
+        if (attempts === 2) throw new Error("knock failed")
+      },
+      onconnect: () => {
+        if (attempts >= 3) {
+          clearTimeout(timeout)
+          resolve()
+        }
+      },
+    })
+    session.then((s) => (testClient(s) as AMQPClient).socket?.destroy()).catch(reject)
+  })
+  await recovered
+  expect(attempts).toBeGreaterThanOrEqual(3)
+})
+
 test("ondisconnect fires when the connection drops", async () => {
   const ondisconnect = vi.fn()
   const session = await AMQPSession.connect("amqp://127.0.0.1", {


### PR DESCRIPTION
## Problem

Reported against the new high-level API: *"I need to execute sparoid before every reconnect, there is no beforeConnect hook for this."*

sparoid is port-knocking — it must run **before** the TCP connect to open the broker's firewall. The high-level `AMQPSession` drives reconnects internally (`reconnectLoop` → `client.connect()`), and `onconnect` fires **after** the socket is already up — too late. There was no hook that runs ahead of each connect.

## Change

Adds `beforeConnect?: () => void | Promise<void>` to `AMQPSessionOptions`:

- Awaited before **every** connect attempt — the initial connect and every reconnect.
- A throw in the reconnect path is treated like a failed connect: the loop backs off and retries rather than aborting recovery, so a transient knock failure doesn't kill the session.

```ts
const session = await AMQPSession.connect(url, {
  beforeConnect: () => sparoid.auth(host, 8484, key, hmacKey),
})
```

## Tests

Added: fires before initial connect, fires before every reconnect, is awaited, and a throwing hook on reconnect backs off + retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)