### PR TITLE
AMQPSession: redeclare queues on recovery + onrecoveryerror hook

### DIFF
--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -1,5 +1,5 @@
 import type { AMQPMessage } from "./amqp-message.js"
-import type { ConsumeParams, MessageCount } from "./amqp-channel.js"
+import type { ConsumeParams, MessageCount, QueueParams } from "./amqp-channel.js"
 import type { AMQPProperties } from "./amqp-properties.js"
 import { AMQPConsumer, AMQPGeneratorConsumer } from "./amqp-consumer.js"
 import { AMQPSubscription, AMQPGeneratorSubscription } from "./amqp-subscription.js"
@@ -57,11 +57,22 @@ export class AMQPQueue<
   readonly name: string
   private readonly session: AMQPSession<P, C, KP, KC>
   private readonly subscriptions = new Set<AMQPSubscription>()
+  // Declaration options the session declared this queue with, replayed on
+  // recovery so a queue lost while disconnected is restored before consumers
+  // re-attach. Undefined for server-named queues (not tracked for recovery).
+  private readonly declareParams: QueueParams | undefined
+  private readonly declareArguments: Record<string, unknown> | undefined
 
   /** @internal */
-  constructor(session: AMQPSession<P, C, KP, KC>, name: string) {
+  constructor(
+    session: AMQPSession<P, C, KP, KC>,
+    name: string,
+    declare?: { params?: QueueParams | undefined; arguments?: Record<string, unknown> | undefined },
+  ) {
     this.session = session
     this.name = name
+    this.declareParams = declare?.params
+    this.declareArguments = declare?.arguments
   }
 
   /**
@@ -316,19 +327,29 @@ export class AMQPQueue<
   }
 
   /**
-   * Re-establish all subscriptions after a reconnection.
+   * Re-establish the queue and all its subscriptions after a reconnection.
+   *
+   * Redeclares the queue first — with the same options passed to
+   * {@link AMQPSession#queue} — so a queue lost while disconnected (deleted,
+   * or gone after a failover to a node without it) is recreated before
+   * consumers re-attach. Declare the queue with `passive: false` to have
+   * recovery recreate a missing queue; with `passive: true` recovery instead
+   * fails fast when the queue is absent.
+   *
+   * Throws on the first failure (redeclare or a consumer re-attach). The
+   * session's reconnect loop catches it and routes it to
+   * {@link AMQPSessionOptions.onrecoveryerror}, so callers get an actionable
+   * signal instead of a swallowed warn log.
    * @internal Called by the session's reconnect loop.
    */
   async recover(): Promise<void> {
+    if (this.declareParams || this.declareArguments) {
+      await this.session.withOpsChannel((ch) => ch.queueDeclare(this.name, this.declareParams, this.declareArguments))
+    }
     for (const sub of this.subscriptions) {
-      try {
-        const consumer = await this.openConsumer(sub.def)
-        sub.setConsumer(consumer)
-        this.session.logger?.debug(`Recovered consumer for queue: ${this.name}`)
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-        this.session.logger?.warn(`Failed to recover consumer for queue ${this.name}:`, error.message)
-      }
+      const consumer = await this.openConsumer(sub.def)
+      sub.setConsumer(consumer)
+      this.session.logger?.debug(`Recovered consumer for queue: ${this.name}`)
     }
   }
 

--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -117,6 +117,18 @@ export interface AMQPSessionOptions<
   /** Fires when max reconnect retries are exhausted. */
   onfailed?: (error?: Error) => void
   /**
+   * Fires when auto-recovery of a tracked queue fails after a reconnect —
+   * the queue redeclare or a consumer re-attach threw (e.g. the queue is
+   * gone and was declared `passive: true`, or a declare hit a
+   * `PRECONDITION_FAILED`).
+   *
+   * Without this handler such failures are only logged at warn level, so
+   * there was no way for the application to react. Use it to alert,
+   * rebuild topology, or tear down. `queueName` is the affected queue;
+   * recovery continues for the remaining queues regardless.
+   */
+  onrecoveryerror?: (queueName: string, error: Error) => void
+  /**
    * Fires when the broker blocks the connection from publishing — usually
    * triggered by a resource alarm (memory or disk) on the server. Subsequent
    * publishes reject with `Connection blocked by server` until the broker
@@ -152,6 +164,7 @@ export class AMQPSession<
   private readonly onconnect?: (session: AMQPSession<P, C, KP, KC>) => void
   private readonly ondisconnect?: (error?: Error) => void
   private readonly onfailed?: (error?: Error) => void
+  private readonly onrecoveryerror?: (queueName: string, error: Error) => void
   private readonly onreturn?: (msg: AMQPMessage<P>) => void
 
   private readonly client: AMQPBaseClient
@@ -206,6 +219,7 @@ export class AMQPSession<
     if (options?.onconnect) this.onconnect = options.onconnect
     if (options?.ondisconnect) this.ondisconnect = options.ondisconnect
     if (options?.onfailed) this.onfailed = options.onfailed
+    if (options?.onrecoveryerror) this.onrecoveryerror = options.onrecoveryerror
     if (options?.onreturn) this.onreturn = options.onreturn
     if (options?.onblocked) this.client.onblocked = options.onblocked
     if (options?.onunblocked) this.client.onunblocked = options.onunblocked
@@ -446,7 +460,12 @@ export class AMQPSession<
       if (name === "") return new AMQPQueue<P, C, KP, KC>(this, res.name)
       const existing = this.queues.get(res.name)
       if (existing) return existing
-      const q = new AMQPQueue<P, C, KP, KC>(this, res.name)
+      // Keep the declaration options so the queue can be redeclared on
+      // recovery after a reconnect (see AMQPQueue#recover).
+      const q = new AMQPQueue<P, C, KP, KC>(this, res.name, {
+        params: declarationParams,
+        ...(queueArguments && { arguments: queueArguments }),
+      })
       this.queues.set(res.name, q)
       return q
     })
@@ -645,7 +664,13 @@ export class AMQPSession<
   private async recoverQueues(): Promise<void> {
     if (this.client.closed) return
     for (const queue of this.queues.values()) {
-      await queue.recover()
+      try {
+        await queue.recover()
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err))
+        this.client.logger?.warn(`${this.logTag()}: failed to recover queue ${queue.name}:`, error.message)
+        this.onrecoveryerror?.(queue.name, error)
+      }
     }
     for (const rpc of this.rpcClients) {
       try {

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -299,6 +299,71 @@ test("onconnect fires after successful reconnection", async () => {
   expect(count).toBe(2)
 })
 
+test("recover redeclares an auto-deleted queue so its consumer survives reconnect", async () => {
+  const name = "test-recover-redeclare-" + Math.random()
+  const received: string[] = []
+  let connects = 0
+  let resolveReconnect!: () => void
+  const reconnected = new Promise<void>((r) => (resolveReconnect = r))
+  const session = await AMQPSession.connect("amqp://127.0.0.1", {
+    reconnectInterval: 50,
+    maxRetries: 5,
+    onconnect: () => {
+      if (++connects === 2) resolveReconnect()
+    },
+  })
+  try {
+    const q = await session.queue(name, { durable: false, autoDelete: true })
+    await q.subscribe({ noAck: true }, (msg) => {
+      received.push(msg.bodyString() ?? "")
+    })
+    // Drop the socket. The broker removes the autoDelete queue once the
+    // consumer's channel closes, so recovery must redeclare it before the
+    // consumer can re-attach.
+    ;(testClient(session) as AMQPClient).socket?.destroy()
+    await reconnected
+    await q.publish("after-reconnect", { confirm: false })
+    await new Promise((r) => setTimeout(r, 200))
+    expect(received).toContain("after-reconnect")
+  } finally {
+    await session.stop()
+  }
+})
+
+test("onrecoveryerror fires when a tracked passive queue is gone after reconnect", async () => {
+  const name = "test-recovery-error-" + Math.random()
+  let resolveErr!: (e: [string, string]) => void
+  const gotError = new Promise<[string, string]>((resolve, reject) => {
+    resolveErr = resolve
+    setTimeout(() => reject(new Error("onrecoveryerror did not fire within 5s")), 5_000)
+  })
+  const session = await AMQPSession.connect("amqp://127.0.0.1", {
+    reconnectInterval: 50,
+    maxRetries: 5,
+    onrecoveryerror: (queueName, err) => resolveErr([queueName, err.message]),
+  })
+  try {
+    // Create the queue out-of-band so the passive declare succeeds now and
+    // the queue is tracked for recovery with { passive: true }.
+    const ch = await testClient(session).channel()
+    await ch.queueDeclare(name, { durable: false, autoDelete: false })
+    await ch.close()
+    const q = await session.queue(name, { passive: true })
+    await q.subscribe({ noAck: true }, () => {})
+    // Delete the queue, then drop the socket. On reconnect the passive
+    // redeclare hits NOT_FOUND, recovery throws, and onrecoveryerror fires.
+    const ch2 = await testClient(session).channel()
+    await ch2.queueDelete(name)
+    await ch2.close()
+    ;(testClient(session) as AMQPClient).socket?.destroy()
+    const [queueName, msg] = await gotError
+    expect(queueName).toBe(name)
+    expect(msg).toMatch(/not.?found|404/i)
+  } finally {
+    await session.stop()
+  }
+})
+
 test("ondisconnect fires when the connection drops", async () => {
   const ondisconnect = vi.fn()
   const session = await AMQPSession.connect("amqp://127.0.0.1", {


### PR DESCRIPTION
## Problem

Reported against the new high-level API: *"On recoverQueues I need to redeclare the queue with `passive: false`; there is no way to do this. recoverQueues just restarts the consumer, then if the queue is gone the consumer fails — and that's now a warn log, so no way for me to act on it."*

Two gaps:

1. **No queue redeclare on recovery.** `recoverQueues` only re-ran `basicConsume`. The declaration options passed to `session.queue()` were never stored or replayed, so a queue lost while disconnected was not recreated — the consumer just failed `NOT_FOUND`.
2. **Failures were swallowed.** A recovery failure was logged at warn level only; the application couldn't react.

## Change

- **`AMQPQueue` stores its declaration options** and replays `queueDeclare` on recovery, *before* re-attaching consumers. Declare with `passive: false` to have recovery recreate a missing queue; `passive: true` keeps fail-fast behavior. (A queue declared with no options redeclares non-passively, i.e. recreates.)
- **New `onrecoveryerror?(queueName, error)` option.** When a queue's recovery throws (redeclare or consumer re-attach), the session routes it here and still warn-logs. Recovery continues for the remaining queues.

```ts
const session = await AMQPSession.connect(url, {
  onrecoveryerror: (queue, err) => alert(`recovery failed for ${queue}: ${err.message}`),
})
// passive:false → recovery recreates the queue if it vanished while disconnected
await session.queue("work", { passive: false, durable: true })
```

## Tests

Added: recovery redeclares an auto-deleted queue so its consumer survives a reconnect; `onrecoveryerror` fires with the queue name when a tracked `passive: true` queue is gone after reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)