### PR TITLE
AMQPSession queue: add manualAck subscribe mode

### DIFF
--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -20,9 +20,25 @@ export type QueueSubscribeParams = ConsumeParams & {
   prefetch?: number
   /**
    * Whether to requeue messages that are nacked due to a callback error.
-   * Defaults to `true`.
+   * Defaults to `true`. Ignored when `manualAck` is set.
    */
   requeueOnNack?: boolean
+  /**
+   * Take full control of acknowledgement. The broker still tracks delivery
+   * tags (wire-level `noAck` stays `false`, so unacked messages are redelivered
+   * when the channel closes), but the library never acks or nacks for you —
+   * call `msg.ack()` / `msg.nack()` / `msg.reject()` yourself, on whatever
+   * schedule you need.
+   *
+   * Use this when the ack decision outlives the callback: deferred retries
+   * (ack/republish after a delay), batching, or handing the message to another
+   * subsystem. The default auto-ack mode acks as soon as the callback's promise
+   * resolves, which can't express "decide later".
+   *
+   * Mutually exclusive with wire-level `noAck: true` (which disables ack
+   * tracking entirely). Defaults to `false`.
+   */
+  manualAck?: boolean
 }
 
 /** Options for {@link AMQPQueue#publish}. */
@@ -127,11 +143,21 @@ export class AMQPQueue<
     callback?: (msg: AMQPMessage<P>) => void | Promise<void>,
   ): Promise<AMQPSubscription | AMQPGeneratorSubscription<P>> {
     if (typeof params === "function") [callback, params] = [params, undefined]
-    const { prefetch, requeueOnNack = true, ...consumeParams } = params ?? {}
-    // Force noAck: false when auto-acking so the server tracks delivery tags.
-    // basicConsume defaults noAck to true, so we must be explicit.
-    const autoAck = !consumeParams.noAck
-    if (autoAck) consumeParams.noAck = false
+    const { prefetch, requeueOnNack = true, manualAck = false, ...consumeParams } = params ?? {}
+    // Three ack modes:
+    //   manualAck    → server tracks tags (noAck:false), library never acks;
+    //                  the app owns ack/nack/reject timing.
+    //   auto-ack     → ack after the callback resolves, nack on error.
+    //   noAck:true   → no server-side tracking at all (fire-and-forget).
+    // basicConsume defaults noAck to true, so be explicit when we need tracking.
+    let autoAck: boolean
+    if (manualAck) {
+      consumeParams.noAck = false
+      autoAck = false
+    } else {
+      autoAck = !consumeParams.noAck
+      if (autoAck) consumeParams.noAck = false
+    }
 
     const parsers = this.session.parsers
     const coders = this.session.coders
@@ -147,6 +173,7 @@ export class AMQPQueue<
       queueName: this.name,
       consumeParams,
       requeueOnNack,
+      manualAck,
       ...(wrappedCallback !== undefined && { callback: wrappedCallback }),
       ...(prefetch !== undefined && { prefetch }),
       ...(parsers && { parsers }),
@@ -369,8 +396,11 @@ function wrapCallbackWithAutoDecodeAndAck<P extends ParserMap>(
   if (!callback) return undefined
   if (!opts.autoAck) {
     return async (msg: AMQPMessage) => {
-      // Nobody awaits this delivery, so an uncaught decode or callback error
-      // becomes an unhandledRejection. No-ack can't nack, so just log.
+      // Covers both noAck:true and manualAck: the library doesn't ack/nack
+      // here. Nobody awaits this delivery, so an uncaught decode or callback
+      // error would become an unhandledRejection — log it. In manualAck the
+      // app owns ack/nack/reject (including requeue); in noAck there are no
+      // delivery tags to act on.
       try {
         if (opts.parsers || opts.coders) await decodeMessage(msg, opts.parsers ?? {}, opts.coders ?? {})
         await callback(msg as AMQPMessage<P>)

--- a/src/amqp-subscription.ts
+++ b/src/amqp-subscription.ts
@@ -15,6 +15,8 @@ export interface ConsumerDefinition {
   parsers?: ParserMap
   coders?: CoderMap
   requeueOnNack?: boolean
+  /** App owns ack/nack; the library never acks. See {@link QueueSubscribeParams.manualAck}. */
+  manualAck?: boolean
 }
 
 /**
@@ -126,7 +128,9 @@ export class AMQPGeneratorSubscription<P extends ParserMap = {}>
   }
 
   async *[Symbol.asyncIterator](): AsyncGenerator<AMQPMessage<P>, void, undefined> {
-    const autoAck = !this.def.consumeParams.noAck
+    // manualAck keeps wire-level tracking (noAck:false) but leaves acking to
+    // the caller, so the iterator must not auto-ack the previous message.
+    const autoAck = !this.def.consumeParams.noAck && !this.def.manualAck
     const requeueOnNack = this.def.requeueOnNack ?? true
     let prev: AMQPMessage | undefined
     while (!this.stopped) {

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -191,6 +191,80 @@ test("session.subscribe supports prefetch option", () =>
     await sub.cancel()
   }))
 
+test("manualAck: a callback that returns without acking leaves the message unacked", () =>
+  withSession(async (session) => {
+    const name = "test-manual-ack-" + Math.random()
+    const q = await session.queue(name, { durable: false, autoDelete: false })
+    try {
+      await q.publish("hold-me", { confirm: false })
+      let deliveries = 0
+      const sub = await q.subscribe({ manualAck: true }, () => {
+        deliveries++
+        // Intentionally do NOT ack — the library must not ack for us.
+      })
+      await new Promise((r) => setTimeout(r, 150))
+      expect(deliveries).toBe(1)
+      // Closing the channel requeues the still-unacked message.
+      await sub.cancel()
+      const requeued = await q.get({ noAck: true })
+      expect(requeued?.bodyString()).toBe("hold-me")
+      expect(requeued?.redelivered).toBe(true)
+    } finally {
+      await q.delete()
+    }
+  }))
+
+test("manualAck: the app can ack on its own schedule after the callback returns", () =>
+  withSession(async (session) => {
+    const name = "test-manual-ack-deferred-" + Math.random()
+    const q = await session.queue(name, { durable: false, autoDelete: false })
+    try {
+      await q.publish("ack-later", { confirm: false })
+      const sub = await q.subscribe({ manualAck: true }, (msg) => {
+        // Defer the ack past the callback return — the auto-ack model acks as
+        // soon as this resolves and can't express "decide later"; manualAck can.
+        setTimeout(() => {
+          void msg.ack()
+        }, 50)
+      })
+      await new Promise((r) => setTimeout(r, 200))
+      await sub.cancel()
+      // The deferred ack settled the message, so nothing is requeued.
+      const leftover = await q.get({ noAck: true })
+      expect(leftover).toBeNull()
+    } finally {
+      await q.delete()
+    }
+  }))
+
+test("manualAck: the app can nack-requeue on its own schedule", () =>
+  withSession(async (session) => {
+    const name = "test-manual-nack-" + Math.random()
+    const q = await session.queue(name, { durable: false, autoDelete: false })
+    try {
+      await q.publish("retry-me", { confirm: false })
+      let deliveries = 0
+      const sub = await q.subscribe({ manualAck: true }, (msg) => {
+        deliveries++
+        if (deliveries === 1) {
+          // Defer a requeue; the broker redelivers to this same consumer.
+          setTimeout(() => {
+            void msg.nack(true)
+          }, 50)
+        } else {
+          void msg.ack()
+        }
+      })
+      await new Promise((r) => setTimeout(r, 300))
+      expect(deliveries).toBeGreaterThanOrEqual(2)
+      await sub.cancel()
+      const leftover = await q.get({ noAck: true })
+      expect(leftover).toBeNull()
+    } finally {
+      await q.delete()
+    }
+  }))
+
 test("session.subscribe yields messages via async generator", () =>
   withSession(async (session) => {
     const q = await session.queue("test-generator-" + Math.random(), { durable: false, autoDelete: true })


### PR DESCRIPTION
## Problem
Reported while app ported to the high-level API:

> The callback that gets the message — when it returns, the client acks the message. But in the webhooks system we do a `setTimeout` and wait for a period before acking. This doesn't go hand-in-hand with how the high-level client behaves.

The callback `subscribe` contract auto-acks the moment the callback's promise **resolves** (and nacks on throw). The webhooks delayed-retry logic decides ack/reject *after* the callback has already returned (`setTimeout(() => handleFailedMessage(msg), requeueTime)`), so auto-ack settles the message too early and the retry semantics are lost.

There was no escape hatch:
- auto-ack (`noAck:false`) → library acks on callback return.
- `noAck:true` → no delivery-tag tracking at all; the app can't ack/nack/reject.

No mode meant "broker tracks tags, but **I** decide when to ack."

## Change

Adds `manualAck?: boolean` to `QueueSubscribeParams`. With it:

- Wire-level `noAck` stays `false` — the broker tracks delivery tags and redelivers unacked messages when the channel closes (same safety as auto-ack).
- The library **never** acks or nacks. The app calls `msg.ack()` / `msg.nack()` / `msg.reject()` itself, on any schedule.

Threaded through the generator subscription too (opts out of the auto-ack-previous behavior). `msg.ack()` already guards double-ack, so it composes safely.

```ts
await queue.subscribe({ manualAck: true, prefetch: 10 }, (msg) => {
  process(msg)
    .then(() => msg.ack())
    .catch(() => setTimeout(() => msg.reject(true), requeueDelay)) // ack/reject on your own clock
})
```

This is the high-level equivalent of what the app does today on the low-level API, while keeping reconnect, consumer recovery, and auto-decode.

## Tests

Added: a returning callback that doesn't ack leaves the message unacked (redelivered after channel close); the app can ack on its own schedule after the callback returns (nothing requeued); the app can nack-requeue on its own schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)