### PR TITLE
feat(session): add awaited beforeConnect hook

### DIFF
--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -92,6 +92,18 @@ export interface AMQPSessionOptions<
    */
   channelMax?: number
   /**
+   * Runs before every connection attempt — the initial connect and every
+   * reconnect — and is awaited before the socket opens. Use it for setup
+   * that must complete before the broker is reachable, e.g. firewall
+   * authorization (sparoid / port knocking) or refreshing a credential.
+   *
+   * Unlike {@link onconnect}, this is awaited: if it throws on a reconnect
+   * the attempt is treated as a failed connect and the backoff loop retries
+   * (so a transient authorization failure doesn't tear down the session).
+   * On the initial connect a throw rejects {@link AMQPSession.connect}.
+   */
+  beforeConnect?: () => void | Promise<void>
+  /**
    * Fires after a successful (re)connection — both the initial connect and
    * every reconnect after consumer recovery completes. Registering here
    * rather than after `connect()` resolves means a single handler covers
@@ -149,6 +161,7 @@ export class AMQPSession<
   KP extends keyof P & string = never,
   KC extends keyof C & string = never,
 > {
+  private readonly beforeConnect?: () => void | Promise<void>
   private readonly onconnect?: (session: AMQPSession<P, C, KP, KC>) => void
   private readonly ondisconnect?: (error?: Error) => void
   private readonly onfailed?: (error?: Error) => void
@@ -203,6 +216,7 @@ export class AMQPSession<
     if (options?.coders) this.coders = options.coders
     if (options?.defaultContentType) this.defaultContentType = options.defaultContentType
     if (options?.defaultContentEncoding) this.defaultContentEncoding = options.defaultContentEncoding
+    if (options?.beforeConnect) this.beforeConnect = options.beforeConnect
     if (options?.onconnect) this.onconnect = options.onconnect
     if (options?.ondisconnect) this.ondisconnect = options.ondisconnect
     if (options?.onfailed) this.onfailed = options.onfailed
@@ -285,6 +299,7 @@ export class AMQPSession<
       }
       client = new AMQPClient(u.toString(), options?.tlsOptions, options?.logger)
     }
+    await options?.beforeConnect?.()
     await client.connect()
     const session = new AMQPSession(client, options)
     client.logger?.info(`${session.logTag()}: connected`)
@@ -606,8 +621,11 @@ export class AMQPSession<
       await this.waitBeforeRetry(delay)
       if (this.stopped) continue // stop() was called during the wait
 
-      // Attempt to connect — retry on failure
+      // Attempt to connect — retry on failure. beforeConnect runs first (and
+      // is awaited) so firewall authorization / credential refresh completes
+      // before the socket opens; a throw here is treated like a failed connect.
       try {
+        await this.beforeConnect?.()
         await this.client.connect()
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err))

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -1523,6 +1523,76 @@ test("returned messages are decoded via session parsers before onreturn", async 
   }
 })
 
+test("beforeConnect runs and is awaited before the initial connect", async () => {
+  let ranBeforeConnect = false
+  const session = await AMQPSession.connect("amqp://127.0.0.1", {
+    beforeConnect: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      ranBeforeConnect = true
+    },
+  })
+  try {
+    // connect() only resolves after the awaited beforeConnect completes.
+    expect(ranBeforeConnect).toBe(true)
+    expect(session.closed).toBe(false)
+  } finally {
+    await session.stop()
+  }
+})
+
+test("beforeConnect runs again before each reconnect", async () => {
+  let connects = 0
+  let befores = 0
+  const reconnected = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("did not reconnect within 5s")), 5_000)
+    AMQPSession.connect("amqp://127.0.0.1", {
+      reconnectInterval: 50,
+      maxRetries: 5,
+      beforeConnect: () => {
+        befores++
+      },
+      onconnect: () => {
+        connects++
+        if (connects === 2) {
+          clearTimeout(timeout)
+          resolve()
+        }
+      },
+    })
+      .then((s) => (testClient(s) as AMQPClient).socket?.destroy())
+      .catch(reject)
+  })
+  await reconnected
+  // Once before the initial connect, once before the reconnect.
+  expect(befores).toBe(2)
+})
+
+test("a throwing beforeConnect on reconnect is retried, not fatal", async () => {
+  let attempts = 0
+  const reconnected = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("did not recover within 5s")), 5_000)
+    AMQPSession.connect("amqp://127.0.0.1", {
+      reconnectInterval: 50,
+      maxRetries: 10,
+      beforeConnect: () => {
+        attempts++
+        // Fail the first reconnect attempt (attempt 2 overall); recover after.
+        if (attempts === 2) throw new Error("authorization not ready")
+      },
+      onconnect: () => {
+        if (attempts >= 3) {
+          clearTimeout(timeout)
+          resolve()
+        }
+      },
+    })
+      .then((s) => (testClient(s) as AMQPClient).socket?.destroy())
+      .catch(reject)
+  })
+  await reconnected
+  expect(attempts).toBeGreaterThanOrEqual(3)
+})
+
 test("onblocked / onunblocked can be wired through options", async () => {
   // Triggering connection.blocked requires hitting a broker resource alarm,
   // which isn't safe to do in a shared test broker. Instead, verify the


### PR DESCRIPTION
## Background

`AMQPSession` (4.0) gives you automatic reconnection, but there's no way to run code *before* the socket opens. This surfaced while adopting the session in a downstream service that has to perform single-packet firewall authorization (port knocking) before every connection — the firewall only opens the AMQP port after the knock, and it has to happen again on every reconnect, not just the first connect.

`onconnect` doesn't fit: it fires *after* the connection is up, and it's fire-and-forget, so it can't gate the connection. There was no hook on the path that matters.

## Summary

Adds `beforeConnect?: () => void | Promise<void>` to `AMQPSessionOptions`. It runs before every connection attempt — the initial connect and every reconnect — and is **awaited** before `client.connect()`, so async setup (firewall authorization, credential refresh) completes before the socket opens.

- On the initial connect, a throw rejects `AMQPSession.connect()`.
- On a reconnect, a throw is treated like a failed connect: it's logged and the backoff loop retries, so a transient authorization failure doesn't tear down the session.

The asymmetry with `onconnect` (awaited vs. fire-and-forget, before vs. after) is intentional and documented on the option.

## Tests

- `beforeConnect` runs and is awaited before the initial connect
- `beforeConnect` runs again before each reconnect
- a throwing `beforeConnect` on reconnect is retried, not fatal