### PR TITLE
feat(session): add onrecoverfailed hook for consumer recovery

### DIFF
--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -340,6 +340,13 @@ export class AMQPQueue<
 
   /**
    * Re-establish all subscriptions after a reconnection.
+   *
+   * Like the Ruby client, recovery re-consumes only — it does not redeclare
+   * the queue or recreate bindings. Durable topology persists broker-side
+   * across a restart, so re-consume is enough; if a queue was actually lost,
+   * `basicConsume` fails with NOT_FOUND and the failure is reported via
+   * {@link AMQPSessionOptions.onrecoverfailed} so the application can redeclare
+   * and rebind from an {@link AMQPSessionOptions.onconnect} handler.
    * @internal Called by the session's reconnect loop.
    */
   async recover(): Promise<void> {
@@ -349,8 +356,7 @@ export class AMQPQueue<
         sub.setConsumer(consumer)
         this.session.logger?.debug(`Recovered consumer for queue: ${this.name}`)
       } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-        this.session.logger?.warn(`Failed to recover consumer for queue ${this.name}:`, error.message)
+        this.session.recoverFailed(this.name, err instanceof Error ? err : new Error(String(err)))
       }
     }
   }

--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -356,7 +356,8 @@ export class AMQPQueue<
         sub.setConsumer(consumer)
         this.session.logger?.debug(`Recovered consumer for queue: ${this.name}`)
       } catch (err) {
-        this.session.recoverFailed(this.name, err instanceof Error ? err : new Error(String(err)))
+        const error = err instanceof Error ? err : new Error(String(err))
+        this.session.recoverFailed(this.name, error)
       }
     }
   }

--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -129,6 +129,14 @@ export interface AMQPSessionOptions<
   /** Fires when max reconnect retries are exhausted. */
   onfailed?: (error?: Error) => void
   /**
+   * Fires when re-establishing a tracked queue's consumer after a reconnect
+   * fails — typically NOT_FOUND because the queue no longer exists (recovery
+   * re-consumes only, it does not redeclare). The session logs a warning
+   * regardless; register this to react — redeclare and rebind the queue from
+   * an {@link onconnect} handler, alert, or tear down.
+   */
+  onrecoverfailed?: (queueName: string, error: Error) => void
+  /**
    * Fires when the broker blocks the connection from publishing — usually
    * triggered by a resource alarm (memory or disk) on the server. Subsequent
    * publishes reject with `Connection blocked by server` until the broker
@@ -165,6 +173,7 @@ export class AMQPSession<
   private readonly onconnect?: (session: AMQPSession<P, C, KP, KC>) => void
   private readonly ondisconnect?: (error?: Error) => void
   private readonly onfailed?: (error?: Error) => void
+  private readonly onrecoverfailed?: (queueName: string, error: Error) => void
   private readonly onreturn?: (msg: AMQPMessage<P>) => void
 
   private readonly client: AMQPBaseClient
@@ -220,6 +229,7 @@ export class AMQPSession<
     if (options?.onconnect) this.onconnect = options.onconnect
     if (options?.ondisconnect) this.ondisconnect = options.ondisconnect
     if (options?.onfailed) this.onfailed = options.onfailed
+    if (options?.onrecoverfailed) this.onrecoverfailed = options.onrecoverfailed
     if (options?.onreturn) this.onreturn = options.onreturn
     if (options?.onblocked) this.client.onblocked = options.onblocked
     if (options?.onunblocked) this.client.onunblocked = options.onunblocked
@@ -427,6 +437,16 @@ export class AMQPSession<
    */
   removeQueue(name: string): void {
     this.queues.delete(name)
+  }
+
+  /**
+   * Report a queue-recovery failure: log it and forward to the
+   * {@link AMQPSessionOptions.onrecoverfailed} handler if one is registered.
+   * @internal Called by {@link AMQPQueue#recover}.
+   */
+  recoverFailed(queueName: string, error: Error): void {
+    this.client.logger?.warn(`${this.logTag()}: failed to recover queue ${queueName}:`, error.message)
+    this.onrecoverfailed?.(queueName, error)
   }
 
   /**

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -1663,6 +1663,34 @@ test("manualAck: an unacked message is redelivered after a reconnect", async () 
   )
 })
 
+test("onrecoverfailed fires when a tracked queue's consumer can't be recovered", async () => {
+  const name = "test-recoverfail-" + Math.random()
+  const recoverFailed = vi.fn()
+  const failed = new Promise<void>((resolve, reject) => {
+    setTimeout(() => reject(new Error("onrecoverfailed did not fire within 10s")), 10_000)
+    recoverFailed.mockImplementation((queueName: string) => {
+      if (queueName === name) resolve()
+    })
+  })
+  await withSession(
+    async (session) => {
+      const q = await session.queue(name, { durable: true, autoDelete: false })
+      await q.subscribe({ noAck: true }, () => {})
+
+      // Delete the queue out from under the session. Recovery re-consumes only
+      // (no redeclare), so basicConsume hits NOT_FOUND and reports the failure.
+      const raw = await testClient(session).channel()
+      await raw.queueDelete(name)
+      await raw.close()
+      ;(testClient(session) as AMQPClient).socket?.destroy()
+
+      await failed
+      expect(recoverFailed).toHaveBeenCalledWith(name, expect.any(Error))
+    },
+    { reconnectInterval: 50, maxRetries: 5, onrecoverfailed: recoverFailed },
+  )
+})
+
 test("onblocked / onunblocked can be wired through options", async () => {
   // Triggering connection.blocked requires hitting a broker resource alarm,
   // which isn't safe to do in a shared test broker. Instead, verify the


### PR DESCRIPTION
## Background

`AMQPSession` consumer recovery (4.0) re-opens consumers after a reconnect, but swallows failures as a `logger.warn`. When a tracked queue is gone after the reconnect — deleted, or non-durable and lost in a broker restart — `basicConsume` hits NOT_FOUND, the warning scrolls past, and the consumer is silently dead with no signal to the application.

This came up adopting the session in a downstream service whose queue can legitimately disappear across a reconnect; today (on the low-level API) it redeclares by hand and reacts to a missing queue, and it needed a way to keep doing that under the session.

## Summary

Adds `onrecoverfailed?: (queueName, error) => void` to `AMQPSessionOptions`. It fires when a tracked queue's consumer can't be re-established during recovery. The failure is still logged regardless of whether a handler is registered.

Recovery deliberately stays **re-consume only** — it does **not** redeclare queues or recreate bindings. That matches `amqp-client.rb` (the sibling client this one mirrors), which replays nothing on reconnect. Topology recovery inside the client is a known source of drift bugs (a redeclare with stale args, a binding that no longer reflects intent), so the application owns it: redeclare and rebind from an `onconnect` handler (it runs after every reconnect), alert, or tear down. `onrecoverfailed` is the signal that tells it to.

An earlier revision of this PR also redeclared the queue on recovery; that was dropped to keep the client free of topology recovery and consistent with the Ruby client.

## Tests

- `onrecoverfailed` fires when a tracked queue's consumer can't be recovered (queue deleted out from under the session, then reconnect)
