### PR TITLE
feat(queue): add manualAck subscribe mode

### DIFF
--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -20,9 +20,26 @@ export type QueueSubscribeParams = ConsumeParams & {
   prefetch?: number
   /**
    * Whether to requeue messages that are nacked due to a callback error.
-   * Defaults to `true`.
+   * Defaults to `true`. Ignored when `manualAck` is set.
    */
   requeueOnNack?: boolean
+  /**
+   * Take over acknowledgement. The library keeps the broker tracking delivery
+   * tags (wire-level `noAck: false`, so unacked messages are redelivered after
+   * a disconnect) but does not ack or nack for you — call `msg.ack()` /
+   * `msg.nack()` yourself, on whatever schedule you like (after a timer, a
+   * downstream write, a batch). Pair with `prefetch` to bound how many
+   * deliveries can be in flight unacked.
+   *
+   * Note: a delivery tag is only valid on the channel it arrived on. If the
+   * connection drops before you ack, the tag is dead — the broker requeues and
+   * redelivers the message, so `msg.ack()` from a stale timer will reject.
+   * Treat an ack failure as "it'll be redelivered", not message loss.
+   *
+   * Mutually distinct from `noAck: true` (fire-and-forget, no redelivery) and
+   * from the default auto-ack-on-callback-return.
+   */
+  manualAck?: boolean
 }
 
 /** Options for {@link AMQPQueue#publish}. */
@@ -104,7 +121,10 @@ export class AMQPQueue<
     return this
   }
 
-  /** Subscribe with a callback. Messages are acked after the callback returns, nacked on error. */
+  /**
+   * Subscribe with a callback. Messages are acked after the callback returns,
+   * nacked on error. Pass `{ manualAck: true }` to ack yourself instead.
+   */
   subscribe(callback: (msg: AMQPMessage<P>) => void | Promise<void>): Promise<AMQPSubscription>
   /** Subscribe with a callback and custom params. */
   subscribe(
@@ -127,11 +147,13 @@ export class AMQPQueue<
     callback?: (msg: AMQPMessage<P>) => void | Promise<void>,
   ): Promise<AMQPSubscription | AMQPGeneratorSubscription<P>> {
     if (typeof params === "function") [callback, params] = [params, undefined]
-    const { prefetch, requeueOnNack = true, ...consumeParams } = params ?? {}
-    // Force noAck: false when auto-acking so the server tracks delivery tags.
-    // basicConsume defaults noAck to true, so we must be explicit.
-    const autoAck = !consumeParams.noAck
-    if (autoAck) consumeParams.noAck = false
+    const { prefetch, requeueOnNack = true, manualAck = false, ...consumeParams } = params ?? {}
+    // manualAck and auto-ack both need the server to track delivery tags, so
+    // force wire-level noAck: false (basicConsume defaults it to true). They
+    // differ only in who acks: the library on callback return (auto) vs. the
+    // caller, whenever they choose (manual).
+    const autoAck = !consumeParams.noAck && !manualAck
+    if (autoAck || manualAck) consumeParams.noAck = false
 
     const parsers = this.session.parsers
     const coders = this.session.coders
@@ -147,6 +169,7 @@ export class AMQPQueue<
       queueName: this.name,
       consumeParams,
       requeueOnNack,
+      manualAck,
       ...(wrappedCallback !== undefined && { callback: wrappedCallback }),
       ...(prefetch !== undefined && { prefetch }),
       ...(parsers && { parsers }),

--- a/src/amqp-subscription.ts
+++ b/src/amqp-subscription.ts
@@ -15,6 +15,7 @@ export interface ConsumerDefinition {
   parsers?: ParserMap
   coders?: CoderMap
   requeueOnNack?: boolean
+  manualAck?: boolean
 }
 
 /**
@@ -126,7 +127,7 @@ export class AMQPGeneratorSubscription<P extends ParserMap = {}>
   }
 
   async *[Symbol.asyncIterator](): AsyncGenerator<AMQPMessage<P>, void, undefined> {
-    const autoAck = !this.def.consumeParams.noAck
+    const autoAck = !this.def.consumeParams.noAck && !this.def.manualAck
     const requeueOnNack = this.def.requeueOnNack ?? true
     let prev: AMQPMessage | undefined
     while (!this.stopped) {

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -1593,6 +1593,76 @@ test("a throwing beforeConnect on reconnect is retried, not fatal", async () => 
   expect(attempts).toBeGreaterThanOrEqual(3)
 })
 
+test("manualAck: callback return does not ack — the caller acks on its own schedule", () =>
+  withSession(async (session) => {
+    const q = await session.queue("test-manualack-" + Math.random(), { durable: false, autoDelete: true })
+    const received: string[] = []
+    const held: AMQPMessage[] = []
+    // prefetch: 1 means the broker won't deliver the second message until the
+    // first is acked — only true when wire-level noAck is false, which proves
+    // manualAck keeps the server tracking delivery tags.
+    const sub = await q.subscribe({ manualAck: true, prefetch: 1 }, (msg) => {
+      received.push(msg.bodyString() || "")
+      held.push(msg)
+    })
+
+    await q.publish("m1", { confirm: false })
+    await q.publish("m2", { confirm: false })
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    // m2 is withheld: the callback returned for m1 but the library didn't ack.
+    expect(received).toEqual(["m1"])
+
+    await held[0]!.ack()
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    expect(received).toEqual(["m1", "m2"])
+
+    await held[1]!.ack()
+    await sub.cancel()
+  }))
+
+test("manualAck: an unacked message is redelivered after a reconnect", async () => {
+  let connects = 0
+  let resolveReconnected!: () => void
+  const reconnected = new Promise<void>((resolve, reject) => {
+    resolveReconnected = resolve
+    setTimeout(() => reject(new Error("did not reconnect within 10s")), 10_000)
+  })
+  await withSession(
+    async (session) => {
+      const q = await session.queue("test-manualack-redeliver-" + Math.random(), {
+        durable: true,
+        autoDelete: false,
+      })
+      const received: string[] = []
+      const sub = await q.subscribe({ manualAck: true, prefetch: 1 }, (msg) => {
+        received.push(msg.bodyString() || "")
+        // never ack — the broker must requeue and redeliver on reconnect
+      })
+
+      await q.publish("redeliver-me", { confirm: false })
+      await new Promise((resolve) => setTimeout(resolve, 150))
+      expect(received).toEqual(["redeliver-me"])
+      ;(testClient(session) as AMQPClient).socket?.destroy()
+
+      await reconnected
+      await new Promise((resolve) => setTimeout(resolve, 200))
+      // Delivered once before the drop, redelivered after recovery.
+      expect(received.length).toBeGreaterThanOrEqual(2)
+      expect(received.every((b) => b === "redeliver-me")).toBe(true)
+
+      await sub.cancel()
+      await q.delete()
+    },
+    {
+      reconnectInterval: 50,
+      maxRetries: 5,
+      onconnect: () => {
+        if (++connects === 2) resolveReconnected()
+      },
+    },
+  )
+})
+
 test("onblocked / onunblocked can be wired through options", async () => {
   // Triggering connection.blocked requires hitting a broker resource alarm,
   // which isn't safe to do in a shared test broker. Instead, verify the


### PR DESCRIPTION
## Background

`AMQPQueue.subscribe()` (4.0) acks a message when the callback's returned promise resolves. That's the right default, but it couples acking to callback return. Some consumers can't ack there: they ack after a timer fires, after a downstream write confirms, or in batches — completion is driven by something other than the callback returning.

The existing escape hatch, `noAck: true`, is the wrong tool: it sets wire-level no-ack, so the broker stops tracking delivery tags and won't redeliver on a disconnect. The wire flag and the library's auto-ack decision were the same knob, so there was no way to get "broker tracks tags and redelivers, but I ack when I'm ready."

This came up adopting the session in a downstream service that acks from a deferred timer rather than synchronously when the message handler returns.

## Summary

Adds `manualAck?: boolean` to `QueueSubscribeParams`. With `manualAck: true`:

- wire-level `noAck` stays `false`, so the broker tracks delivery tags and redelivers unacked messages after a disconnect
- the library does **not** ack or nack — the caller calls `msg.ack()` / `msg.nack()` on its own schedule
- works in both callback and generator subscription modes
- pair with `prefetch` to bound how many deliveries can be in flight unacked

Documented caveat: a delivery tag is only valid on the channel it arrived on. If the connection drops before you ack, the tag is dead and the broker requeues/redelivers, so a `msg.ack()` from a stale timer rejects — treat that as "it'll be redelivered," not message loss.

`manualAck` is distinct from `noAck: true` (fire-and-forget, no redelivery) and from the default auto-ack-on-callback-return.

## Tests

- `manualAck`: callback return does not ack; with `prefetch: 1` the second message is withheld until the caller acks the first (proves no auto-ack and that the server is still tracking tags)
- `manualAck`: an unacked message is redelivered after a reconnect