### PR TITLE
fix: respect frameBuffer.byteOffset when creating frame parse view (Node >= 24.18 crash)

### DIFF
--- a/src/amqp-socket-client.ts
+++ b/src/amqp-socket-client.ts
@@ -187,7 +187,7 @@ export class AMQPClient extends AMQPBaseClient {
       this.framePos += copied
       bufPos += copied
       if (this.framePos === this.frameSize) {
-        const view = new AMQPView(this.frameBuffer.buffer, 0, this.frameSize)
+        const view = new AMQPView(this.frameBuffer.buffer, this.frameBuffer.byteOffset, this.frameSize)
         this.parseFrames(view)
         this.frameSize = this.framePos = 0
       }

--- a/src/amqp-websocket-client.ts
+++ b/src/amqp-websocket-client.ts
@@ -191,7 +191,7 @@ export class AMQPWebSocketClient extends AMQPBaseClient {
       this.framePos += copyBytes
       bufPos += copyBytes
       if (this.framePos === this.frameSize) {
-        const view = new AMQPView(this.frameBuffer.buffer, 0, this.frameSize)
+        const view = new AMQPView(this.frameBuffer.buffer, this.frameBuffer.byteOffset, this.frameSize)
         this.parseFrames(view)
         this.frameSize = this.framePos = 0
       }


### PR DESCRIPTION
Fixes #255.

`Buffer.allocUnsafe(frameMax)` returns a pooled slice with `byteOffset != 0` on Node >= 24.18 / 26.3 (`Buffer.poolSize` raised 8 KiB -> 64 KiB in nodejs/node#63597). The frame-reassembly parse view was constructed with a hardcoded offset 0 into the backing pool ArrayBuffer, reading unrelated memory and crashing with `Frame end out of range` whenever a frame spans socket reads.

One-line fix in both the TCP and WebSocket clients: pass `this.frameBuffer.byteOffset` instead of `0`. Correct on every Node version — on <= 24.17 the 8 KiB allocation bypassed the pool so `byteOffset` was already 0.

Verified with the repro in #255: Node 22.15 passes before and after; Node 24.19 crashes before, passes after (200/200 messages).