### PR TITLE
Fix leaky channelMax tests

### DIFF
--- a/test-browser/websocket.ts
+++ b/test-browser/websocket.ts
@@ -768,6 +768,8 @@ test("raises when channelMax is reached", async () => {
   // make sure other channels still work
   const ch1 = await conn.channel(1)
   await expect(ch1.basicQos(10)).resolves.toBeUndefined()
+
+  await expect(conn.close()).resolves.toBeUndefined()
 }, 20_000)
 
 test("should fail to connect to an AMQP port", async () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -840,6 +840,8 @@ test("raises when channelMax is reached", async () => {
   // make sure other channels still work
   const ch1 = await conn.channel(1)
   await expect(ch1.basicQos(10)).resolves.toBeUndefined()
+
+  await expect(conn.close()).resolves.toBeUndefined()
 }, 10_000)
 
 test("client can negotiate channelMax", async () => {


### PR DESCRIPTION
### Why was this needed?
Fix leaky connection in "raises when channelMax is reached" tests
Example: https://github.com/cloudamqp/amqp-client.js/actions/runs/31084579374/attempts/1

The channelMax test opens conn.channelMax channels and asserts that the next channel() call rejects, but it never closes the connection. Every opened channel is left live when the test exits.

### How was this fixed?
Explicitly await conn.close() at the end of both the Node (test/test.ts) and browser (test-browser/websocket.ts) versions. 