### PR TITLE
fix: only read the frame size once the header is complete

### DIFF
--- a/src/amqp-socket-client.ts
+++ b/src/amqp-socket-client.ts
@@ -139,7 +139,10 @@ export class AMQPClient extends AMQPBaseClient {
     while (bufPos < bufLen) {
       // read frame size of next frame
       if (this.frameSize === 0) {
-        // first 7 bytes of a frame was split over two reads, this reads the second part
+        // the first 7 bytes of a frame were split over reads; this reads the rest.
+        // The header can span more than two reads, so the size may only be taken
+        // once all 7 bytes are in frameBuffer -- and from offset 3, where the size
+        // field sits in frameBuffer regardless of bufPos.
         if (this.framePos !== 0) {
           const copied = buf.copy(this.frameBuffer, this.framePos, bufPos, bufPos + 7 - this.framePos)
           if (copied === 0)
@@ -147,9 +150,10 @@ export class AMQPClient extends AMQPBaseClient {
               `Copied 0 bytes framePos=${this.framePos} bufPos=${bufPos} bytesWritten=${bufLen}`,
               this,
             )
-          this.frameSize = this.frameBuffer.readInt32BE(bufPos + 3) + 8
           this.framePos += copied
           bufPos += copied
+          if (this.framePos < 7) continue // header still incomplete, wait for more
+          this.frameSize = this.frameBuffer.readInt32BE(3) + 8
           continue
         }
         // frame header is split over reads, copy to frameBuffer


### PR DESCRIPTION
Fixes #206.

The split-header branch takes the frame size from `frameBuffer` without checking that all 7 header bytes have arrived. Its comment assumes the header spans exactly two reads; over **three or more**, `buf.copy` copies fewer bytes than requested and the size is read from a half-filled buffer — i.e. from the previous frame's bytes.

`frameSize` is then garbage, so the assembler fills to `frameMax`, cannot advance, and `buf.copy` returns 0 — the `Copied 0 bytes ... framePos=<frameMax>` in #206.

Also reads the size from offset `3` rather than `bufPos + 3`, since that offset indexes `frameBuffer`. Equivalent today (the branch is only reachable with `bufPos === 0`) but correct on its own terms.

Verified with the repro in #206, against this tree — before: `framePos=8 frameSize=1342374152`, then `Copied 0 bytes ... framePos=8192`. After: `framePos=0 frameSize=0`, and 2000 following heartbeats consumed cleanly.

Independent of #255 — this reproduces on any Node version.