### PR TITLE
Fix: catch async consumer callback rejections in deliver()

### DIFF
--- a/src/amqp-channel.ts
+++ b/src/amqp-channel.ts
@@ -932,7 +932,12 @@ export class AMQPChannel {
     queueMicrotask(() => {
       const consumer = this.consumers.get(message.consumerTag)
       if (consumer) {
-        consumer.onMessage(message)
+        // The callback may be async; catch rejections so they don't surface as
+        // unhandled promise rejections (e.g. when the channel closes mid-callback
+        // and pending operations awaited inside it reject).
+        const ret = consumer.onMessage(message)
+        if (ret instanceof Promise)
+          ret.catch((err) => this.logger?.warn("Consumer", message.consumerTag, "callback failed:", err))
       } else {
         this.logger?.warn("Consumer", message.consumerTag, "not available on channel", this.id)
       }


### PR DESCRIPTION
We've ran into a lot of channelMax errors when running tests/ci, the errors weren't from the channelMax test. 
Vitest tagged them there, it was the last test before delayed async rejections surfaced. 
All errors are identical: Error: Connection closed by client.

### Why is this happening
Our async consumer callback fired fire-and-forget. 
Channel close rejects publishes awaited inside callback → callback promise rejects → no handler → unhandled rejection flood.

### How is this a fix
We'll capture returned promise, attach .catch → rejection now handled (logged), never escapes. 
Also covers any throwing async consumer callback, not just close case.