### PR TITLE
Fix: session stop unhandled rejections

### DIFF
--- a/src/amqp-queue.ts
+++ b/src/amqp-queue.ts
@@ -333,7 +333,7 @@ export class AMQPQueue<
    */
   async delete(params?: { ifUnused?: boolean; ifEmpty?: boolean }): Promise<MessageCount> {
     const result = await this.session.withOpsChannel((ch) => ch.queueDelete(this.name, params))
-    this.cancelAll()
+    await this.cancelAll()
     this.session.removeQueue(this.name)
     return result
   }
@@ -364,13 +364,18 @@ export class AMQPQueue<
 
   /**
    * Cancel all subscriptions without closing the connection.
+   *
+   * Awaits the cancels (consumer cancel + channel close) so callers can
+   * finish tearing down before closing the connection — otherwise the
+   * in-flight basic.cancel RPCs race the connection close and reject as
+   * unhandled "Connection closed by client" rejections. `subscription.cancel`
+   * swallows wire-level errors, so this never rejects.
    * @internal Called by the session on stop().
    */
-  cancelAll(): void {
-    for (const sub of this.subscriptions) {
-      sub.cancel().catch(() => {})
-    }
+  async cancelAll(): Promise<void> {
+    const subs = [...this.subscriptions]
     this.subscriptions.clear()
+    await Promise.all(subs.map((sub) => sub.cancel()))
   }
 
   private async openConsumer(def: ConsumerDefinition): Promise<AMQPConsumer | AMQPGeneratorConsumer> {

--- a/src/amqp-session.ts
+++ b/src/amqp-session.ts
@@ -603,9 +603,10 @@ export class AMQPSession<
   async stop(reason?: string): Promise<void> {
     this.stopped = true
     this.cancelWait()
-    for (const queue of this.queues.values()) {
-      queue.cancelAll()
-    }
+    // Await the cancels before closing the connection below — otherwise the
+    // in-flight basic.cancel RPCs race the connection close and surface as
+    // unhandled "Connection closed by client" rejections.
+    await Promise.all([...this.queues.values()].map((queue) => queue.cancelAll()))
     this.queues.clear()
     for (const rpc of this.rpcClients) {
       rpc.close().catch(() => {})

--- a/test/amqp-session.ts
+++ b/test/amqp-session.ts
@@ -1389,7 +1389,10 @@ test("consumeOne with no timeout waits forever (cancelled via timer)", () =>
       autoDelete: true,
     })
     // Race the indefinite wait against a sentinel that publishes after a delay.
-    setTimeout(() => void q.publish("delivered"), 50)
+    // Swallow the publish rejection: withSession stops the session as soon as
+    // the test body returns, which can close the connection before the confirm
+    // for this fire-and-forget publish arrives.
+    setTimeout(() => void q.publish("delivered").catch(() => {}), 50)
     const msg = await q.consumeOne()
     expect(msg.bodyString()).toBe("delivered")
   }))


### PR DESCRIPTION
Two distinct sources in the session teardown path, both racing conn.close():
https://github.com/cloudamqp/amqp-client.js/actions/runs/32109993632/job/95627131824#step:10:114

### Library bug — session.stop() fired cancels without awaiting. 
`stop()` called `queue.cancelAll()` (which fires basic.cancel RPCs) then closed the connection. Close-ok reached the client while cancels were in flight → their rejections escaped. 
**Fix:** `cancelAll()` now returns a promise and awaits the cancels; `stop()` awaits all of them before closing. `queue.delete()` awaits too.

### Test bug — fire-and-forget publish.
test/amqp-session.ts:1392 did void `q.publish("delivered")` on a confirm channel. 
`withSession` stops the session the moment the body returns, closing the connection before the publish-confirm arrives → the unconfirmed publish rejected unhandled. The library correctly rejects pending confirms on close; a fire-and-forget publish is the caller's job. 
**Fix:** `.catch(() => {})`