### PR TITLE
docs: name the AMQP 0-9-1 brokers this client works with, expand npm keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 AMQP 0-9-1 TypeScript client both for Node.js and browsers (using WebSocket). This library is intended to replace all other Node.js AMQP libraries.
 
+It works with any AMQP 0-9-1 broker — RabbitMQ, LavinMQ, Amazon MQ for RabbitMQ, Apache Qpid and CloudAMQP's hosted RabbitMQ and LavinMQ instances all speak the same protocol, so the same code runs against all of them.
+
 [API documentation](https://cloudamqp.github.io/amqp-client.js/).
 
 This library is Promise-based and hence works very well with async/await. It's secure by default, for instance, publishes aren't fulfilled until either the data has been sent on the wire (so that back propagation is respected), or if the channel has Publish Confirms enabled, it isn't fulfilled until the server has acknowledged that the message has been enqueued.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AMQP 0-9-1 TypeScript client both for Node.js and browsers (using WebSocket). This library is intended to replace all other Node.js AMQP libraries.
 
-It works with any AMQP 0-9-1 broker — RabbitMQ, LavinMQ, Amazon MQ for RabbitMQ, Apache Qpid and CloudAMQP's hosted RabbitMQ and LavinMQ instances all speak the same protocol, so the same code runs against all of them.
+It works with any AMQP 0-9-1 broker: RabbitMQ, LavinMQ and Apache Qpid, whether self-hosted or managed by a provider such as CloudAMQP or Amazon MQ — they all speak the same protocol, so the same code runs against all of them.
 
 [API documentation](https://cloudamqp.github.io/amqp-client.js/).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudamqp/amqp-client",
   "version": "4.1.0",
-  "description": "AMQP 0-9-1 client, both for browsers (WebSocket) and node (TCP Socket)",
+  "description": "AMQP 0-9-1 client for RabbitMQ, LavinMQ and other AMQP brokers, both for browsers (WebSocket) and node (TCP Socket)",
   "type": "module",
   "main": "lib/cjs/index.js",
   "types": "types/index.d.ts",
@@ -58,8 +58,20 @@
   "repository": "github:cloudamqp/amqp-client.js",
   "keywords": [
     "amqp",
+    "amqp-0-9-1",
+    "amqp-client",
+    "amqplib",
     "rabbitmq",
-    "amqplib"
+    "lavinmq",
+    "cloudamqp",
+    "message-queue",
+    "messaging",
+    "queue",
+    "pubsub",
+    "broker",
+    "websocket",
+    "browser",
+    "typescript"
   ],
   "author": "CloudAMQP <contact@cloudamqp.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
The README only ever described the library as an "AMQP 0-9-1 client", and the npm keywords were `["amqp", "rabbitmq", "amqplib"]`. People looking for a RabbitMQ or LavinMQ client for Node.js have little to match on, so the project is harder to find than it should be.

### README

Adds one sentence to the intro naming the brokers it actually works with:

> It works with any AMQP 0-9-1 broker: RabbitMQ, LavinMQ and Apache Qpid, whether self-hosted or managed by a provider such as CloudAMQP or Amazon MQ — they all speak the same protocol, so the same code runs against all of them.

### package.json

npm search matches on `keywords` and `description`, which is where most package discovery actually happens, so the same terms now appear there.

`description` gains the broker names:

> AMQP 0-9-1 client for RabbitMQ, LavinMQ and other AMQP brokers, both for browsers (WebSocket) and node (TCP Socket)

`keywords` goes from 3 entries to 15, covering the protocol (`amqp-0-9-1`, `amqp-client`), the brokers and provider (`lavinmq`, `cloudamqp`, keeping `rabbitmq`/`amqplib`), the generic category people search when they don't know the protocol name (`message-queue`, `messaging`, `queue`, `pubsub`, `broker`), and what makes this client distinct (`websocket`, `browser`, `typescript`).

### Notes on what's named and what isn't

- **ActiveMQ is deliberately left out.** Both Classic and Artemis speak AMQP 1.0 only — a different wire protocol, not a version bump — so this client fails at the handshake against them (`Connection attempt from non AMQP v1.0 client`). [AMQ-5332](https://issues.apache.org/jira/browse/AMQ-5332) is the open request to add 0-9-1 support. Claiming compatibility would send people to a broker where the library doesn't work.
- **Amazon MQ is listed as a provider, not a broker**, since it's a managed service and the 0-9-1 support comes from its RabbitMQ engine.

Metadata only — no code or behaviour changes. `npm run format:check` passes.