### PR TITLE
docs: attribute PR #268 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Heartbeat timeout closed the socket without going through the normal close path, so open channels were never marked closed and `ondisconnect` never fired. Now the socket is destroyed with the timeout error instead, routing through the standard error/close handling. Thanks [@kevin192291](https://github.com/kevin192291) for the fix ([#268](https://github.com/cloudamqp/amqp-client.js/pull/268), fixes [#267](https://github.com/cloudamqp/amqp-client.js/issues/267))
+
 ## [4.1.0] - 2026-08-19
 
 ### Added


### PR DESCRIPTION
## Summary

PR #268 fixed a bug where a heartbeat timeout closed the socket directly instead of going through the normal error/close event flow, so open channels never got marked closed and `ondisconnect` never fired. This adds the changelog entry crediting that fix under an Unreleased section, following the project's existing convention of cutting a versioned section from Unreleased at release time.

## Test plan

- [x] `npm run format:check`